### PR TITLE
Add REST API endpoint to replace AJAX callback

### DIFF
--- a/assets/js/admin-auto_tweet.js
+++ b/assets/js/admin-auto_tweet.js
@@ -61,17 +61,14 @@
 		data[adminAutotweet.enableAutotweetKey] = status;
 		data[adminAutotweet.tweetBodyKey] = $tweetText.val();
 
-		// Process AJAX action.
-		$.ajax( adminAutotweet.restUrl, {
-			beforeSend: function( xhr ) {
-				pendingStatus();
-				xhr.setRequestHeader( 'X-WP-Nonce', adminAutotweet.nonce );
-			},
-			data: data,
-			dataType: 'json',
-			error: onRequestFail,
-			success: function( response ) {
-				// Remove the pending and enabled/disabled classes depending on AJAX response
+		wp.apiFetch(
+			{
+				url: adminAutotweet.restUrl,
+				data: data,
+				method: 'POST',
+			}
+		).then(
+			function( response ) {
 				$icon.removeClass( 'pending' );
 				if ( true === response.enabled ) {
 					$icon.toggleClass( 'enabled' );
@@ -80,9 +77,8 @@
 					$icon.toggleClass( 'disabled' );
 					$tweetPost.prop( 'checked', false );
 				}
-			},
-			type: 'POST',
-		} );
+			}
+		).catch( onRequestFail );
 	}
 
 	/**

--- a/assets/js/admin-auto_tweet.js
+++ b/assets/js/admin-auto_tweet.js
@@ -12,6 +12,7 @@
 		$editLink = $( '#tenup-auto-tweet-edit' ),
 		$editBody = $( '#tenup-auto-tweet-override-body' ),
 		$hideLink = $( '.cancel-tweet-text' ),
+		errorMessageContainer = document.getElementById( 'tenup-autotweet-error-message' ),
 		counterWrap = document.getElementById( 'tenup-auto-tweet-counter-wrap' ),
 		limit = 280;
 
@@ -47,7 +48,16 @@
 	/**
 	 * Callback for failed requests.
 	 */
-	function onRequestFail() {
+	function onRequestFail( error ) {
+		var errorText = '';
+		if ( 'statusText' in error && 'status' in error ) {
+			errorText = adminAutotweet.errorText + ' ' + error.status + ': ' + error.statusText;
+		} else {
+			errorText = adminAutotweet.unkonwnErrorText;
+		}
+
+		errorMessageContainer.innerText = errorText;
+
 		$icon.removeClass( 'pending' );
 		$tweetPost.prop( 'checked', false );
 	}
@@ -66,11 +76,23 @@
 				url: adminAutotweet.restUrl,
 				data: data,
 				method: 'POST',
+				parse: false // We'll check the response for errors.
 			}
 		).then(
 			function( response ) {
+				if ( ! response.ok ) {
+					throw response;
+				}
+
+				return response.json();
+			}
+		)
+		.then(
+			function( data ) {
+				errorMessageContainer.innerText = '';
+
 				$icon.removeClass( 'pending' );
-				if ( response.enabled ) {
+				if ( data.enabled ) {
 					$icon.toggleClass( 'enabled' );
 					$tweetPost.prop( 'checked', true );
 				} else {

--- a/assets/js/admin-auto_tweet.js
+++ b/assets/js/admin-auto_tweet.js
@@ -73,7 +73,7 @@
 			success: function( response ) {
 				// Remove the pending and enabled/disabled classes depending on AJAX response
 				$icon.removeClass( 'pending' );
-				if ( 'true' === response.enabled ) {
+				if ( true === response.enabled ) {
 					$icon.toggleClass( 'enabled' );
 					$tweetPost.prop( 'checked', true );
 				} else {

--- a/assets/js/admin-auto_tweet.js
+++ b/assets/js/admin-auto_tweet.js
@@ -51,7 +51,7 @@
 	function onRequestFail( error ) {
 		var errorText = '';
 		if ( 'statusText' in error && 'status' in error ) {
-			errorText = adminAutotweet.errorText + ' ' + error.status + ': ' + error.statusText;
+			errorText = `${adminAutotweet.errorText} ${error.status}: ${error.statusText}`;
 		} else {
 			errorText = adminAutotweet.unkonwnErrorText;
 		}

--- a/assets/js/admin-auto_tweet.js
+++ b/assets/js/admin-auto_tweet.js
@@ -3,108 +3,101 @@
  *
  * @todo soooo much dependency :facepalm:
  */
-(function ($) {
+( function( $ ) {
 	'use strict';
 
-	var $tweetPost = $('#tenup-auto-tweet-enable'),
-		$icon = $('#tenup-auto-tweet-icon'),
-		$postTitle = $('input[name="post_title"]'),
-		$tweetText = $('#tenup-auto-tweet-text'),
-		$editLink = $('#tenup-auto-tweet-edit'),
-		$editBody = $('#tenup-auto-tweet-override-body'),
-		$hideLink = $('.cancel-tweet-text'),
-		counterWrap = document.getElementById('tenup-auto-tweet-counter-wrap'),
+	const $tweetPost = $( '#tenup-auto-tweet-enable' ),
+		$icon = $( '#tenup-auto-tweet-icon' ),
+		$tweetText = $( '#tenup-auto-tweet-text' ),
+		$editLink = $( '#tenup-auto-tweet-edit' ),
+		$editBody = $( '#tenup-auto-tweet-override-body' ),
+		$hideLink = $( '.cancel-tweet-text' ),
+		counterWrap = document.getElementById( 'tenup-auto-tweet-counter-wrap' ),
 		limit = 280;
 
-
 	// Add enabled class if checked
-	if ($tweetPost.prop('checked')) {
-		$icon.addClass('enabled')
+	if ( $tweetPost.prop( 'checked' ) ) {
+		$icon.addClass( 'enabled' );
 	}
 
 	// Event handlers.
-	$tweetPost.on('click', handleRequest );
-	$tweetText.change(handleRequest);
-	$editLink.on('click', function() {
+	$tweetPost.on( 'click', handleRequest );
+	$tweetText.change( handleRequest );
+	$editLink.on( 'click', function() {
 		$editBody.slideToggle();
 		updateRemainingField();
-		$(this).hide();
-	})
-	$tweetText.on('keyup', function() {
+		$( this ).hide();
+	} );
+	$tweetText.on( 'keyup', function() {
 		updateRemainingField();
-	})
-	$hideLink.on('click', function(e) {
+	} );
+	$hideLink.on( 'click', function( e ) {
 		e.preventDefault();
-		$('#tenup-auto-tweet-override-body').slideToggle();
+		$( '#tenup-auto-tweet-override-body' ).slideToggle();
 		$editLink.show();
-	});
+	} );
 
 	// Runs on page load to auto-enable posts to be tweeted
-	window.onload = function(event) {
-		if ( '' === adminTUAT.currentStatus ) {
-			handleRequest(event, true)
+	window.onload = function( event ) {
+		if ( '' === adminAutotweet.currentStatus ) {
+			handleRequest( event, true );
 		}
+	};
+
+	/**
+	 * Callback for failed requests.
+	 */
+	function onRequestFail() {
+		$icon.removeClass( 'pending' );
+		$tweetPost.prop( 'checked', false );
 	}
 
 	/**
 	 * AJAX handler
 	 * @param event
 	 */
-	function handleRequest(event, status = $tweetPost.prop('checked') ) {
+	function handleRequest( event, status = $tweetPost.prop( 'checked' ) ) {
+		const data = {};
+		data[adminAutotweet.enableAutotweetKey] = status;
+		data[adminAutotweet.tweetBodyKey] = $tweetText.val();
 
 		// Process AJAX action.
-		$.ajax(ajaxurl, {
-			'data': {
-				'action': 'tenup_auto_tweet',
-				'checked': status,
-				'value': $tweetPost.val(),
-				'nonce': adminTUAT.nonce,
-				'post_id': adminTUAT.postId,
-				'text': $tweetText.val(),
-				'type': event.type
+		$.ajax( adminAutotweet.restUrl, {
+			beforeSend: function( xhr ) {
+				pendingStatus();
+				xhr.setRequestHeader( 'X-WP-Nonce', adminAutotweet.nonce );
 			},
-			'beforeSend': pendingStatus(),
-			'dataType': 'json',
-			'success': function (response) {
-
-				// If successful
-				if (response.success) {
-
-					// Remove the pending and enabled/disabled classes depending on AJAX response
-					$icon.removeClass('pending');
-					if ('true' === response.data.enabled) {
-						$icon.toggleClass('enabled');
-						$tweetPost.prop('checked', true);
-					} else {
-						$icon.toggleClass('disabled');
-						$tweetPost.prop('checked', false);
-					}
-
-					// Something went wrong with the AJAX request. Remove the class and uncheck the box.
+			data: data,
+			dataType: 'json',
+			error: onRequestFail,
+			success: function( response ) {
+				// Remove the pending and enabled/disabled classes depending on AJAX response
+				$icon.removeClass( 'pending' );
+				if ( 'true' === response.enabled ) {
+					$icon.toggleClass( 'enabled' );
+					$tweetPost.prop( 'checked', true );
 				} else {
-					$icon.removeClass('pending');
-					$tweetPost.prop('checked', false);
+					$icon.toggleClass( 'disabled' );
+					$tweetPost.prop( 'checked', false );
 				}
-
-			}
-
-		});
-	};
+			},
+			type: 'POST',
+		} );
+	}
 
 	/**
 	 * Updates the counter
 	 */
 	function updateRemainingField() {
-		var count = $tweetText.val().length;
+		const count = $tweetText.val().length;
 
 		$( counterWrap ).text( count );
 
 		// Toggle the .over-limit class.
-		if (limit < count) {
-			counterWrap.classList.add('over-limit');
-
-		} else if (counterWrap.classList.contains('over-limit')) {
-			counterWrap.classList.remove('over-limit');
+		if ( limit < count ) {
+			counterWrap.classList.add( 'over-limit' );
+		} else if ( counterWrap.classList.contains( 'over-limit' ) ) {
+			counterWrap.classList.remove( 'over-limit' );
 		}
 	}
 
@@ -112,9 +105,8 @@
 	 * Helper for toggling classes to indicate something is happening.
 	 */
 	function pendingStatus() {
-		$icon.toggleClass('pending');
-		$icon.removeClass('enabled');
-		$icon.removeClass('disabled');
+		$icon.toggleClass( 'pending' );
+		$icon.removeClass( 'enabled' );
+		$icon.removeClass( 'disabled' );
 	}
-
-})(jQuery);
+} )( jQuery );

--- a/assets/js/admin-auto_tweet.js
+++ b/assets/js/admin-auto_tweet.js
@@ -6,7 +6,7 @@
 ( function( $ ) {
 	'use strict';
 
-	const $tweetPost = $( '#tenup-auto-tweet-enable' ),
+	var $tweetPost = $( '#tenup-auto-tweet-enable' ),
 		$icon = $( '#tenup-auto-tweet-icon' ),
 		$tweetText = $( '#tenup-auto-tweet-text' ),
 		$editLink = $( '#tenup-auto-tweet-edit' ),
@@ -57,7 +57,7 @@
 	 * @param event
 	 */
 	function handleRequest( event, status = $tweetPost.prop( 'checked' ) ) {
-		const data = {};
+		var data = {};
 		data[adminAutotweet.enableAutotweetKey] = status;
 		data[adminAutotweet.tweetBodyKey] = $tweetText.val();
 
@@ -89,7 +89,7 @@
 	 * Updates the counter
 	 */
 	function updateRemainingField() {
-		const count = $tweetText.val().length;
+		var count = $tweetText.val().length;
 
 		$( counterWrap ).text( count );
 

--- a/assets/js/admin-auto_tweet.js
+++ b/assets/js/admin-auto_tweet.js
@@ -70,7 +70,7 @@
 		).then(
 			function( response ) {
 				$icon.removeClass( 'pending' );
-				if ( true === response.enabled ) {
+				if ( response.enabled ) {
 					$icon.toggleClass( 'enabled' );
 					$tweetPost.prop( 'checked', true );
 				} else {

--- a/includes/admin/assets.php
+++ b/includes/admin/assets.php
@@ -49,11 +49,40 @@ function maybe_enqueue_classic_editor_assets( $hook ) {
 		return;
 	}
 
+	$api_fetch_handle = 'wp-api-fetch';
+	if ( ! wp_script_is( $api_fetch_handle, 'registered' ) ) {
+		wp_register_script(
+			$api_fetch_handle,
+			trailingslashit( TUAT_URL ) . 'dist/api-fetch.js',
+			[],
+			'3.4.0',
+			true
+		);
+
+		wp_add_inline_script(
+			$api_fetch_handle,
+			sprintf(
+				'wp.apiFetch.use( wp.apiFetch.createNonceMiddleware( "%s" ) );',
+				( wp_installing() && ! is_multisite() ) ? '' : wp_create_nonce( 'wp_rest' )
+			),
+			'after'
+		);
+
+		wp_add_inline_script(
+			$api_fetch_handle,
+			sprintf(
+				'wp.apiFetch.use( wp.apiFetch.createRootURLMiddleware( "%s" ) );',
+				esc_url_raw( get_rest_url() )
+			),
+			'after'
+		);
+	}
+
 	$handle = 'admin_tenup-auto-tweet';
 	wp_enqueue_script(
 		$handle,
 		trailingslashit( TUAT_URL ) . 'assets/js/admin-auto_tweet.js',
-		[ 'jquery' ],
+		[ 'jquery', 'wp-api-fetch' ],
 		TUAT_VERSION,
 		true
 	);

--- a/includes/admin/assets.php
+++ b/includes/admin/assets.php
@@ -128,7 +128,9 @@ function localize_data( $handle = SCRIPT_HANDLE ) {
 	$post_id = intval( get_the_ID() );
 
 	if ( empty( $post_id ) ) {
-		$post_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0; // phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$post_id = intval(
+			filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT )  // Filter removes all characters except digits.
+		);
 	}
 
 	$localization = [

--- a/includes/admin/assets.php
+++ b/includes/admin/assets.php
@@ -8,8 +8,10 @@
 
 namespace TenUp\AutoTweet\Admin\Assets;
 
-use function TenUp\Auto_Tweet\Utils\{get_autotweet_meta, opted_into_autotweet};
-use const TenUp\Auto_Tweet\Core\Post_Meta\{ENABLE_AUTOTWEET_KEY, TWEET_BODY_KEY};
+use function TenUp\Auto_Tweet\Utils\get_autotweet_meta;
+use function TenUp\Auto_Tweet\Utils\opted_into_autotweet;
+use const TenUp\Auto_Tweet\Core\Post_Meta\ENABLE_AUTOTWEET_KEY;
+use const TenUp\Auto_Tweet\Core\Post_Meta\TWEET_BODY_KEY;
 use function TenUp\AutoTweet\REST\post_autotweet_meta_rest_route;
 
 const SCRIPT_HANDLE = 'autotweet';

--- a/includes/admin/assets.php
+++ b/includes/admin/assets.php
@@ -136,9 +136,11 @@ function localize_data( $handle = SCRIPT_HANDLE ) {
 	$localization = [
 		'enabled'            => get_autotweet_meta( $post_id, ENABLE_AUTOTWEET_KEY ),
 		'enableAutotweetKey' => ENABLE_AUTOTWEET_KEY,
+		'errorText'          => __( 'Error', 'autotweet' ),
 		'nonce'              => wp_create_nonce( 'wp_rest' ),
 		'restUrl'            => rest_url( post_autotweet_meta_rest_route( $post_id ) ),
 		'tweetBodyKey'       => TWEET_BODY_KEY,
+		'unknownErrorText'   => __( 'An unknown error occurred', 'autotweet' ),
 	];
 
 	wp_localize_script( $handle, 'adminAutotweet', $localization );

--- a/includes/admin/post-meta.php
+++ b/includes/admin/post-meta.php
@@ -17,12 +17,12 @@ use function TenUp\Auto_Tweet\Utils\delete_autotweet_meta;
 /**
  * The meta prefix that all meta related keys should have
  */
-const META_PREFIX = 'tenup-autotweet';
+const META_PREFIX = 'tenup-auto-tweet';
 
 /**
  * Enable auto-tweet checkbox
  */
-const ENABLE_AUTOTWEET_KEY = 'enable-autotweet';
+const ENABLE_AUTOTWEET_KEY = 'auto-tweet';
 
 /**
  * Holds the auto-tweet boddy

--- a/includes/admin/post-meta.php
+++ b/includes/admin/post-meta.php
@@ -12,6 +12,7 @@ namespace TenUp\Auto_Tweet\Core\Post_Meta;
  */
 use TenUp\Auto_Tweet\Utils as Utils;
 use function TenUp\Auto_Tweet\Utils\update_autotweet_meta;
+use function TenUp\Auto_Tweet\Utils\delete_autotweet_meta;
 
 /**
  * The meta prefix that all meta related keys should have

--- a/includes/admin/post-meta.php
+++ b/includes/admin/post-meta.php
@@ -278,6 +278,8 @@ function _safe_markup_default() {
 		<p><a href="#" class="hide-if-no-js cancel-tweet-text">Hide</a></p>
 	</div>
 
+	<p id="tenup-autotweet-error-message"></p>
+
 	<?php
 	return ob_get_clean();
 }

--- a/includes/admin/post-meta.php
+++ b/includes/admin/post-meta.php
@@ -248,7 +248,6 @@ function markup_unknown( $status_meta ) {
  */
 function _safe_markup_default() {
 
-	wp_nonce_field( 'tenup_auto_tweet_meta_fields', 'tenup_auto_tweet_meta_nonce' );
 	ob_start();
 	?>
 	<label for="tenup-auto-tweet-enable">

--- a/includes/admin/post-meta.php
+++ b/includes/admin/post-meta.php
@@ -56,36 +56,70 @@ function setup() {
  * @return void
  */
 function save_tweet_meta( $post_id ) {
-
-	// Check check.
-	if (
-		! isset( $_POST['tenup_auto_tweet_meta_nonce'] ) ||
-		! wp_verify_nonce(
-			sanitize_text_field( wp_unslash( $_POST['tenup_auto_tweet_meta_nonce'] ) ),
-			'tenup_auto_tweet_meta_fields'
-		) ||
-		( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) ||
-		! current_user_can( 'edit_post', $post_id )
-	) {
+	if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || ! current_user_can( 'edit_post', $post_id ) ) {
 		return;
 	}
 
-	// Auto-tweet post.
-	if ( isset( $_POST[ META_PREFIX ][ ENABLE_AUTOTWEET_KEY ] ) ) {
-		update_autotweet_meta( $post_id, ENABLE_AUTOTWEET_KEY, (int) $_POST[ META_PREFIX ][ ENABLE_AUTOTWEET_KEY ] );
-	} else {
-		update_autotweet_meta( $post_id, ENABLE_AUTOTWEET_KEY, 0 );
+	$form_data = sanitize_autotweet_meta_data(
+		// Using FILTER_DEFAULT here as data is being passed to sanitize function.
+		filter_input( INPUT_POST, META_PREFIX, FILTER_DEFAULT, FILTER_REQUIRE_ARRAY )
+	);
+
+	save_autotweet_meta_data( $post_id, $form_data );
+}
+
+/**
+ * Sanitizes autotweet-related fields passed while saving a post.
+ *
+ * @since 1.0.0
+ * @param array $data Form data.
+ * @return array Filtered form data.
+ */
+function sanitize_autotweet_meta_data( $data ) {
+	if ( empty( $data ) || ! is_array( $data ) ) {
+		return [];
 	}
 
-	// Auto-tweet body.
-	if ( isset( $_POST[ META_PREFIX ][ TWEET_BODY_KEY ] ) ) {
-		update_autotweet_meta(
-			$post_id,
-			TWEET_BODY_KEY,
-			sanitize_text_field( wp_unslash( $_POST[ META_PREFIX ][ TWEET_BODY_KEY ] ) )
-		);
-	} else {
-		delete_autotweet_meta( $post_id, TWEET_BODY_KEY );
+	$filtered_data = [];
+	foreach ( $data as $key => $value ) {
+		switch ( $key ) {
+			case ENABLE_AUTOTWEET_KEY:
+				$filtered_data[ $key ] = boolval( $value );
+				break;
+
+			case TWEET_BODY_KEY:
+				$filtered_data[ $key ] = sanitize_text_field( $value );
+		}
+	}
+
+	return $filtered_data;
+}
+
+/**
+ * Saves fields in an array of autotweet meta.
+ *
+ * @since 1.0.0
+ * @param int   $post_id WP_Post ID.
+ * @param array $data Associative array of data to save.
+ */
+function save_autotweet_meta_data( $post_id, $data ) {
+	if ( empty( $data ) || ! is_array( $data ) ) {
+		return;
+	}
+
+	foreach ( $data as $key => $value ) {
+		switch ( $key ) {
+			case ENABLE_AUTOTWEET_KEY:
+				update_autotweet_meta( $post_id, ENABLE_AUTOTWEET_KEY, $value );
+				break;
+
+			case TWEET_BODY_KEY:
+				if ( ! empty( $value ) ) {
+					update_autotweet_meta( $post_id, TWEET_BODY_KEY, $value );
+				} else {
+					delete_autotweet_meta( $post_id, TWEET_BODY_KEY );
+				}
+		}
 	}
 }
 

--- a/includes/admin/post-meta.php
+++ b/includes/admin/post-meta.php
@@ -21,7 +21,7 @@ const META_PREFIX = 'tenup-autotweet';
 /**
  * Enable auto-tweet checkbox
  */
-const ENABLE_AUTOTWEET_KEY = 'enable_autotweet';
+const ENABLE_AUTOTWEET_KEY = 'enable-autotweet';
 
 /**
  * Holds the auto-tweet boddy

--- a/includes/admin/post-meta.php
+++ b/includes/admin/post-meta.php
@@ -11,28 +11,29 @@ namespace TenUp\Auto_Tweet\Core\Post_Meta;
  * Aliases
  */
 use TenUp\Auto_Tweet\Utils as Utils;
+use function TenUp\Auto_Tweet\Utils\update_autotweet_meta;
 
 /**
  * The meta prefix that all meta related keys should have
  */
-const META_PREFIX = 'tenup-auto-tweet';
+const META_PREFIX = 'tenup-autotweet';
 
 /**
  * Enable auto-tweet checkbox
  */
-const TWEET_KEY = 'auto-tweet';
+const ENABLE_AUTOTWEET_KEY = 'enable_autotweet';
 
 /**
  * Holds the auto-tweet boddy
  */
-const TWEET_BODY = 'tweet-body';
+const TWEET_BODY_KEY = 'tweet-body';
 
 /**
  * Holds the formatted response object from Twitter.
  *
  * @see post-transition.php
  */
-const STATUS_KEY = 'twitter-status';
+const TWITTER_STATUS_KEY = 'twitter-status';
 
 /**
  * The setup function
@@ -40,85 +41,9 @@ const STATUS_KEY = 'twitter-status';
  * @return void
  */
 function setup() {
-
-	add_action( 'wp_ajax_tenup_auto_tweet', __NAMESPACE__ . '\ajax_save_tweet_meta' );
 	add_action( 'post_submitbox_misc_actions', __NAMESPACE__ . '\tweet_submitbox_callback', 15 );
 	add_action( 'tenup_auto_tweet_metabox', __NAMESPACE__ . '\render_tweet_submitbox', 10, 1 );
 	add_action( 'save_post', __NAMESPACE__ . '\save_tweet_meta', 10, 1 );
-}
-
-/**
- * AJAX save and response handler for our auto-tweet checkbox.
- *
- * @return void
- */
-function ajax_save_tweet_meta() {
-
-	// Verify nonce.
-	if (
-		! isset( $_GET['nonce'] ) ||
-		! isset( $_GET['post_id'] ) ||
-		! isset( $_GET['checked'] ) ||
-		! isset( $_GET['text'] ) ||
-		! isset( $_GET['value'] ) ||
-		! wp_verify_nonce( sanitize_key( wp_unslash( $_GET['nonce'] ) ), 'admin_tenup-auto-tweet' ) ) {
-		wp_send_json_error( array( 'message' => esc_html__( 'Invalid request.', 'tenup_auto_tweet' ) ) );
-	}
-
-	// One more check to see if the user has permission to edit the post.
-	$post_id = (int) $_GET['post_id'];
-	if ( ! current_user_can( 'edit_post', $post_id ) ) {
-		wp_send_json_error( array( 'message' => esc_html__( 'Permission denied.', 'tenup_auto_tweet' ) ) );
-	}
-
-	// Santize values.
-	$checked_safe       = sanitize_text_field( wp_unslash( $_GET['checked'] ) );
-	$text_override_safe = sanitize_text_field( wp_unslash( $_GET['text'] ) );
-
-	// Auto-tweet post.
-	if ( 'true' === $checked_safe ) {
-
-		// Holds the response array.
-		$response = array(
-			'enabled' => 'true',
-			'message' => __( 'Auto-tweet enabled.', 'tenup_auto_tweet' ),
-		);
-
-		delete_post_meta( $post_id, META_PREFIX . '_' . TWEET_KEY );
-		add_post_meta( $post_id, META_PREFIX . '_' . TWEET_KEY, sanitize_text_field( wp_unslash( $_GET['value'] ) ) );
-		// If there's a manual tweet text.
-		if ( ! empty( $text_override_safe ) ) {
-			delete_post_meta( $post_id, META_PREFIX . '_' . TWEET_BODY );
-			add_post_meta( $post_id, META_PREFIX . '_' . TWEET_BODY, sanitize_text_field( wp_unslash( $_GET['text'] ) ) );
-			$response['override'] = 'true';
-		} else {
-			delete_post_meta( $post_id, META_PREFIX . '_' . TWEET_BODY );
-		}
-
-		wp_send_json_success( $response );
-
-		// Delete the value if the checkbox is empty.
-	} elseif ( 'false' === $checked_safe ) {
-		delete_post_meta( $post_id, META_PREFIX . '_' . TWEET_KEY );
-		add_post_meta( $post_id, META_PREFIX . '_' . TWEET_KEY, 0 );
-
-		wp_send_json_success(
-			array(
-				'enabled' => 'false',
-				'message' => __( 'Auto-tweet disabled.', 'tenup_auto_tweet' ),
-			)
-		);
-
-		// Something happened during meta save or delete.
-	} else {
-		wp_send_json_error(
-			array(
-				'enabled' => 'false',
-				'message' => esc_html__( 'Unable to save auto-tweet status. Please try again.', 'tenup_auto_tweet' ),
-			)
-		);
-	}
-
 }
 
 /**
@@ -134,7 +59,10 @@ function save_tweet_meta( $post_id ) {
 	// Check check.
 	if (
 		! isset( $_POST['tenup_auto_tweet_meta_nonce'] ) ||
-		! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['tenup_auto_tweet_meta_nonce'] ) ), 'tenup_auto_tweet_meta_fields' ) ||
+		! wp_verify_nonce(
+			sanitize_text_field( wp_unslash( $_POST['tenup_auto_tweet_meta_nonce'] ) ),
+			'tenup_auto_tweet_meta_fields'
+		) ||
 		( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) ||
 		! current_user_can( 'edit_post', $post_id )
 	) {
@@ -142,17 +70,21 @@ function save_tweet_meta( $post_id ) {
 	}
 
 	// Auto-tweet post.
-	if ( isset( $_POST['tenup-auto-tweet']['auto-tweet'] ) ) {
-		update_post_meta( $post_id, META_PREFIX . '_' . TWEET_KEY, (int) $_POST['tenup-auto-tweet']['auto-tweet'] );
+	if ( isset( $_POST[ META_PREFIX ][ ENABLE_AUTOTWEET_KEY ] ) ) {
+		update_autotweet_meta( $post_id, ENABLE_AUTOTWEET_KEY, (int) $_POST[ META_PREFIX ][ ENABLE_AUTOTWEET_KEY ] );
 	} else {
-		update_post_meta( $post_id, META_PREFIX . '_' . TWEET_KEY, 0 );
+		update_autotweet_meta( $post_id, ENABLE_AUTOTWEET_KEY, 0 );
 	}
 
 	// Auto-tweet body.
-	if ( isset( $_POST['tenup-auto-tweet']['auto-tweet-text'] ) ) {
-		update_post_meta( $post_id, META_PREFIX . '_' . TWEET_BODY, sanitize_text_field( wp_unslash( $_POST['tenup-auto-tweet']['auto-tweet-text'] ) ) );
+	if ( isset( $_POST[ META_PREFIX ][ TWEET_BODY_KEY ] ) ) {
+		update_autotweet__meta(
+			$post_id,
+			TWEET_BODY_KEY,
+			sanitize_text_field( wp_unslash( $_POST[ META_PREFIX ][ TWEET_BODY_KEY ] ) )
+		);
 	} else {
-		delete_post_meta( $post_id, META_PREFIX . '_' . TWEET_BODY );
+		delete_autotweet_meta( $post_id, TWEET_BODY_KEY );
 	}
 }
 
@@ -193,7 +125,7 @@ function render_tweet_submitbox( $post ) {
 	// If the post is already published the output varies slightly.
 	if ( 'publish' === $post_status ) {
 
-		$twitter_status = Utils\get_auto_tweet_meta( get_the_ID(), STATUS_KEY );
+		$twitter_status = Utils\get_autotweet_meta( get_the_ID(), TWITTER_STATUS_KEY );
 		$status         = isset( $twitter_status['status'] ) ? $twitter_status['status'] : '';
 		switch ( $status ) {
 
@@ -285,19 +217,28 @@ function _safe_markup_default() {
 	ob_start();
 	?>
 	<label for="tenup-auto-tweet-enable">
-		<input type="checkbox" id="tenup-auto-tweet-enable"
-			name="tenup-auto-tweet[auto-tweet]" value="1" <?php checked( Utils\get_auto_tweet_meta( get_the_ID(), 'auto-tweet' ) ); ?>>
+		<input
+			type="checkbox"
+			id="tenup-auto-tweet-enable"
+			name="<?php echo esc_attr( sprintf( '%s[%s]', META_PREFIX, ENABLE_AUTOTWEET_KEY ) ); ?>"
+			value="1"
+			<?php checked( Utils\get_autotweet_meta( get_the_ID(), 'auto-tweet' ) ); ?>
+		>
 		<span id="tenup-auto-tweet-icon" class="dashicons-before dashicons-twitter"></span>
 		<?php esc_html_e( 'Tweet this post', 'tenup_auto_tweet' ); ?>
 		<a href="#edit_tweet_text" id="tenup-auto-tweet-edit"><?php esc_html_e( 'Edit', 'tenup_auto_tweet' ); ?></a>
 	</label>
 
 	<div id="tenup-auto-tweet-override-body" style="display: none;">
-		<label for="tenup-auto-tweet[auto-tweet-text]">
+		<label for="<?php echo esc_attr( sprintf( '%s[%s]', META_PREFIX, TWEET_BODY_KEY ) ); ?>">
 			<?php esc_html_e( 'Custom Message', 'tenup_auto_tweet' ); ?>:
 		</label>
 		<span id="tenup-auto-tweet-counter-wrap" class="alignright">0</span>
-		<textarea id="tenup-auto-tweet-text" name="tenup-auto-tweet[auto-tweet-text]" rows="3"><?php echo esc_textarea( Utils\get_auto_tweet_meta( get_the_ID(), TWEET_BODY ) ); ?></textarea>
+		<textarea
+			id="tenup-auto-tweet-text"
+			name="<?php echo esc_attr( sprintf( '%s[%s]', META_PREFIX, TWEET_BODY_KEY ) ); ?>"
+			rows="3"
+		><?php echo esc_textarea( Utils\get_autotweet_meta( get_the_ID(), TWEET_BODY_KEY ) ); ?></textarea>
 
 		<p><a href="#" class="hide-if-no-js cancel-tweet-text">Hide</a></p>
 	</div>

--- a/includes/admin/post-meta.php
+++ b/includes/admin/post-meta.php
@@ -79,7 +79,7 @@ function save_tweet_meta( $post_id ) {
 
 	// Auto-tweet body.
 	if ( isset( $_POST[ META_PREFIX ][ TWEET_BODY_KEY ] ) ) {
-		update_autotweet__meta(
+		update_autotweet_meta(
 			$post_id,
 			TWEET_BODY_KEY,
 			sanitize_text_field( wp_unslash( $_POST[ META_PREFIX ][ TWEET_BODY_KEY ] ) )

--- a/includes/admin/post-transition.php
+++ b/includes/admin/post-transition.php
@@ -10,7 +10,8 @@ namespace TenUp\Auto_Tweet\Core\Post_Transition;
 use TenUp\Auto_Tweet\Core\Publish_Tweet\Publish_Tweet;
 use TenUp\Auto_Tweet\Core\Post_Meta as Meta;
 use TenUp\Auto_Tweet\Utils as Utils;
-use function TenUp\Auto_Tweet\Utils\{delete_autotweet_meta, update_autotweet_meta};
+use function TenUp\Auto_Tweet\Utils\delete_autotweet_meta;
+use function TenUp\Auto_Tweet\Utils\update_autotweet_meta;
 
 /**
  * Setup function.

--- a/includes/admin/post-transition.php
+++ b/includes/admin/post-transition.php
@@ -10,6 +10,7 @@ namespace TenUp\Auto_Tweet\Core\Post_Transition;
 use TenUp\Auto_Tweet\Core\Publish_Tweet\Publish_Tweet;
 use TenUp\Auto_Tweet\Core\Post_Meta as Meta;
 use TenUp\Auto_Tweet\Utils as Utils;
+use function TenUp\Auto_Tweet\Utils\{delete_autotweet_meta, update_autotweet_meta};
 
 /**
  * Setup function.
@@ -157,8 +158,8 @@ function update_auto_tweet_meta( $post_id, $data ) {
 	 * Update the post meta entry that stores the response
 	 * and remove the "Auto-tweet this post" value as a double-check.
 	 */
-	update_post_meta( $post_id, Meta\META_PREFIX . '_' . Meta\STATUS_KEY, $response );
-	delete_post_meta( $post_id, Meta\META_PREFIX . '_' . Meta\TWEET_KEY );
+	update_autotweet_meta( $post_id, Meta\TWITTER_STATUS_KEY, $response );
+	delete_autotweet_meta( $post_id, Meta\ENABLE_AUTOTWEET_KEY );
 
 	/**
 	 * Fires after the response from Twitter has been written as meta to the post.

--- a/includes/core.php
+++ b/includes/core.php
@@ -13,13 +13,15 @@ const POST_TYPE_SUPPORT_FEATURE = 'tenup-autotweet';
  * The main setup action.
  */
 function setup() {
+	require_once plugin_dir_path( TUAT ) . '/includes/admin/assets.php';
+	require_once plugin_dir_path( TUAT ) . '/includes/admin/settings.php';
+	require_once plugin_dir_path( TUAT ) . '/includes/admin/post-meta.php';
+	require_once plugin_dir_path( TUAT ) . '/includes/admin/post-transition.php';
+	require_once plugin_dir_path( TUAT ) . '/includes/class-publish-tweet.php';
+	require_once plugin_dir_path( TUAT ) . '/includes/rest.php';
 
-	// Includes and requires.
-	require_once 'admin/assets.php';
-	require_once 'admin/settings.php';
-	require_once 'admin/post-meta.php';
-	require_once 'admin/post-transition.php';
-	require_once 'class-publish-tweet.php';
+	\TenUp\AutoTweet\Admin\Assets\add_hook_callbacks();
+	\TenUp\AutoTweet\REST\add_hook_callbacks();
 
 	/**
 	 * Allow others to hook into the core setup action

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -119,6 +119,7 @@ function update_post_autotweet_meta( $request ) {
 
 	save_autotweet_meta_data( $request['id'], $params );
 
+	return new \WP_REST_Response( null, 400 );
 	return rest_ensure_response(
 		[
 			'enabled'  => $params[ ENABLE_AUTOTWEET_KEY ],

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Sets up a WP REST route handling autotweet metadata.
+ *
+ * @since 1.0.0
+ * @package TenUp\Auto_Tweet
+ */
+
+namespace TenUp\AutoTweet\REST;
+
+use WP_REST_Response;
+use WP_REST_Server;
+use const TenUp\Auto_Tweet\Core\Post_Meta\{TWEET_BODY_KEY, ENABLE_AUTOTWEET_KEY};
+use function TenUp\Auto_Tweet\Utils\{delete_autotweet_meta, update_autotweet_meta};
+
+/**
+ * The namespace for plugin REST endpoints.
+ *
+ * @since 1.0.0
+ */
+const REST_NAMESPACE = 'autotweet';
+
+/**
+ * The plugin REST version.
+ *
+ * @since 1.0.0
+ */
+const REST_VERSION = 'v1';
+
+/**
+ * The REST route for autotweet metadata.
+ *
+ * @since 1.0.0
+ */
+const AUTOTWEET_REST_ROUTE = 'post-autotweet-meta';
+
+/**
+ * Adds WP hook callbacks.
+ *
+ * @since 1.0.0
+ */
+function add_hook_callbacks() {
+	add_action( 'rest_api_init', __NAMESPACE__ . '\register_post_autotweet_meta_rest_route' );
+}
+
+/**
+ * Registers the autotweet REST route.
+ *
+ * @since 1.0.0
+ */
+function register_post_autotweet_meta_rest_route() {
+	register_rest_route(
+		sprintf( '%s/%s', REST_NAMESPACE, REST_VERSION ),
+		sprintf( '/%s/(?P<id>[\d]+)', AUTOTWEET_REST_ROUTE ),
+		[
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => __NAMESPACE__ . '\update_post_autotweet_meta',
+			'permission_callback' => __NAMESPACE__ . '\update_post_autotweet_meta_permission_check',
+			'args'                => [
+				'id'                 => [
+					'description' => __( 'Unique identifier for the object.', 'tenup_auto_tweet' ),
+					'required'    => true,
+					'type'        => 'integer',
+				],
+				TWEET_BODY_KEY       => [
+					'description' => __( 'Tweet text, if overriding the default', 'tenup_auto_tweet' ),
+					'required'    => true,
+					'type'        => 'string',
+				],
+				ENABLE_AUTOTWEET_KEY => [
+					'description' => __( 'Whether autotweet is enabled for the current post', 'tenup_auto_tweet' ),
+					'required'    => true,
+					'type'        => 'boolean',
+				],
+			],
+		]
+	);
+}
+
+/**
+ * Provides the autotweet meta rest route for a provided post.
+ *
+ * @since 1.0.0
+ * @param int $post_id Post ID.
+ * @return string The REST route for a post.
+ */
+function post_autotweet_meta_rest_route( $post_id ) {
+	return sprintf( '%s/%s/%s/%d', REST_NAMESPACE, REST_VERSION, AUTOTWEET_REST_ROUTE, intval( $post_id ) );
+}
+
+/**
+ * Checks whether the current user has permission to update autotweet metadata.
+ *
+ * @since 1.0.0
+ * @param WP_REST_Request $request A REST request containing post autotweet metadata to update.
+ * @return boolean
+ */
+function update_post_autotweet_meta_permission_check( $request ) {
+	$id = $request['id'] ? $request['id'] : null;
+
+	if ( empty( $id ) ) {
+		$id = $request->get_attributes()['id'] ? $request->get_attributes()['id'] : null;
+	}
+
+	if ( ! is_int( $id ) || 1 > $id ) {
+		return false;
+	}
+
+	return current_user_can( 'edit_post', $id );
+}
+
+/**
+ * Updates autotweet metadata associated with a post.
+ *
+ * @since 1.0.0
+ * @param WP_REST_Request $request A REST request containing post autotweet metadata to update.
+ * @return WP_REST_Response REST response with information about the current autotweet status.
+ */
+function update_post_autotweet_meta( $request ) {
+	$id = $request['id'] ? $request['id'] : null;
+
+	if ( empty( $id ) ) {
+		$post_id = $request->get_attributes()['id'] ? $request->get_attributes()['id'] : null;
+	}
+
+	$params = $request->get_params();
+
+	$sanitized_tweet_body = trim( sanitize_text_field( wp_unslash( $params[ TWEET_BODY_KEY ] ) ) );
+	if ( ! empty( $sanitized_tweet_body ) ) {
+		update_autotweet_meta( $post_id, TWEET_BODY_KEY, $sanitized_tweet_body );
+	} else {
+		delete_autotweet_meta( $post_id, TWEET_BODY_KEY );
+	}
+
+	update_autotweet_meta( $post_id, ENABLE_AUTOTWEET_KEY, $params[ ENABLE_AUTOTWEET_KEY ] );
+
+	return rest_ensure_response(
+		[
+			'enabled'  => $params[ ENABLE_AUTOTWEET_KEY ],
+			'message'  => __( 'Auto-tweet enabled.', 'tenup_auto_tweet' ),
+			'override' => ! empty( $sanitized_tweet_body ),
+		]
+	);
+}

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -118,11 +118,14 @@ function update_post_autotweet_meta( $request ) {
 	$params = $request->get_params();
 
 	save_autotweet_meta_data( $request['id'], $params );
+	$message = 1 === $params[ ENABLE_AUTOTWEET_KEY ] ?
+		__( 'Auto-tweet enabled.', 'tenup_auto_tweet' ) :
+		__( 'Auto-tweet disabled.', 'tenup_auto_tweet' );
 
 	return rest_ensure_response(
 		[
 			'enabled'  => $params[ ENABLE_AUTOTWEET_KEY ],
-			'message'  => __( 'Auto-tweet enabled.', 'tenup_auto_tweet' ),
+			'message'  => $message,
 			'override' => ! empty( $params[ TWEET_BODY_KEY ] ),
 		]
 	);

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -101,7 +101,7 @@ function update_post_autotweet_meta_permission_check( $request ) {
 	$id = $request['id'] ? $request['id'] : null;
 
 	if ( empty( $id ) ) {
-		$id = $request->get_attributes()['id'] ? $request->get_attributes()['id'] : null;
+		$id = isset( $request->get_attributes()['id'] ) ? $request->get_attributes()['id'] : null;
 	}
 
 	if ( ! is_int( $id ) || 1 > $id ) {
@@ -119,10 +119,10 @@ function update_post_autotweet_meta_permission_check( $request ) {
  * @return WP_REST_Response REST response with information about the current autotweet status.
  */
 function update_post_autotweet_meta( $request ) {
-	$id = $request['id'] ? $request['id'] : null;
+	$post_id = $request['id'] ? $request['id'] : null;
 
-	if ( empty( $id ) ) {
-		$post_id = $request->get_attributes()['id'] ? $request->get_attributes()['id'] : null;
+	if ( empty( $post_id ) ) {
+		$post_id = isset( $request->get_attributes()['id'] ) ? $request->get_attributes()['id'] : null;
 	}
 
 	$params = $request->get_params();

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -119,7 +119,6 @@ function update_post_autotweet_meta( $request ) {
 
 	save_autotweet_meta_data( $request['id'], $params );
 
-	return new \WP_REST_Response( null, 400 );
 	return rest_ensure_response(
 		[
 			'enabled'  => $params[ ENABLE_AUTOTWEET_KEY ],

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -10,8 +10,10 @@ namespace TenUp\AutoTweet\REST;
 
 use WP_REST_Response;
 use WP_REST_Server;
-use const TenUp\Auto_Tweet\Core\Post_Meta\{TWEET_BODY_KEY, ENABLE_AUTOTWEET_KEY};
-use function TenUp\Auto_Tweet\Utils\{delete_autotweet_meta, update_autotweet_meta};
+use const TenUp\Auto_Tweet\Core\Post_Meta\TWEET_BODY_KEY;
+use const TenUp\Auto_Tweet\Core\Post_Meta\ENABLE_AUTOTWEET_KEY;
+use function TenUp\Auto_Tweet\Utils\delete_autotweet_meta;
+use function TenUp\Auto_Tweet\Utils\update_autotweet_meta;
 
 /**
  * The namespace for plugin REST endpoints.

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -57,7 +57,7 @@ function delete_autotweet_meta( $id, $key ) {
  * @return bool
  */
 function maybe_auto_tweet( $post_id ) {
-	return ( '1' === get_autotweet_meta( $post_id, ENABLE_AUTOTWEET_KEY ) ) ? true : false;
+	return ( 1 === intval( get_autotweet_meta( $post_id, ENABLE_AUTOTWEET_KEY ) ) ) ? true : false;
 }
 
 /**

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -9,7 +9,10 @@
 namespace TenUp\Auto_Tweet\Utils;
 
 use const TenUp\Auto_Tweet\Core\POST_TYPE_SUPPORT_FEATURE;
-use const TenUp\Auto_Tweet\Core\Post_Meta\{ENABLE_AUTOTWEET_KEY, META_PREFIX, TWEET_BODY_KEY, TWITTER_STATUS_KEY};
+use const TenUp\Auto_Tweet\Core\Post_Meta\ENABLE_AUTOTWEET_KEY;
+use const TenUp\Auto_Tweet\Core\Post_Meta\META_PREFIX;
+use const TenUp\Auto_Tweet\Core\Post_Meta\TWEET_BODY_KEY;
+use const TenUp\Auto_Tweet\Core\Post_Meta\TWITTER_STATUS_KEY;
 
 /**
  * Helper/Wrapper function for returning the meta entries for auto-tweeting.

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -8,8 +8,8 @@
 
 namespace TenUp\Auto_Tweet\Utils;
 
-use TenUp\Auto_Tweet\Core\Post_Meta as Meta;
 use const TenUp\Auto_Tweet\Core\POST_TYPE_SUPPORT_FEATURE;
+use const TenUp\Auto_Tweet\Core\Post_Meta\{ENABLE_AUTOTWEET_KEY, META_PREFIX, TWEET_BODY_KEY, TWITTER_STATUS_KEY};
 
 /**
  * Helper/Wrapper function for returning the meta entries for auto-tweeting.
@@ -19,9 +19,31 @@ use const TenUp\Auto_Tweet\Core\POST_TYPE_SUPPORT_FEATURE;
  *
  * @return mixed
  */
-function get_auto_tweet_meta( $id, $key ) {
+function get_autotweet_meta( $id, $key ) {
+	return get_post_meta( $id, sprintf( '%s_%s', META_PREFIX, $key ), true );
+}
 
-	return get_post_meta( $id, Meta\META_PREFIX . '_' . $key, true );
+/**
+ * Updates autotweet-related post metadata by prefixing the passed key.
+ *
+ * @param int    $id Post ID.
+ * @param string $key Autotweet meta key.
+ * @param mixed  $value The meta value to save.
+ * @return mixed meta_id if the meta doesn't exist, otherwise returns true on success and false on failure.
+ */
+function update_autotweet_meta( $id, $key, $value ) {
+	return update_post_meta( $id, sprintf( '%s_%s', META_PREFIX, $key ), $value );
+}
+
+/**
+ * Deletes autotweet-related metadata.
+ *
+ * @param int    $id  The post ID.
+ * @param string $key The key of the meta value to delete.
+ * @return boolean False for failure. True for success.
+ */
+function delete_autotweet_meta( $id, $key ) {
+	return delete_post_meta( $id, sprintf( '%s_%s', META_PREFIX, $key ) );
 }
 
 /**
@@ -32,8 +54,7 @@ function get_auto_tweet_meta( $id, $key ) {
  * @return bool
  */
 function maybe_auto_tweet( $post_id ) {
-
-	return ( '1' === get_auto_tweet_meta( $post_id, 'auto-tweet' ) ) ? true : false;
+	return ( '1' === get_autotweet_meta( $post_id, ENABLE_AUTOTWEET_KEY ) ) ? true : false;
 }
 
 /**
@@ -126,7 +147,7 @@ function link_from_twitter( $post_id ) {
  */
 function already_published( $post_id ) {
 
-	$twitter_status = get_auto_tweet_meta( $post_id, Meta\STATUS_KEY );
+	$twitter_status = get_autotweet_meta( $post_id, TWITTER_STATUS_KEY );
 
 	if ( ! empty( $twitter_status ) ) {
 		return ( 'published' === $twitter_status['status'] ) ? true : false;
@@ -146,7 +167,7 @@ function get_tweet_body( $post_id ) {
 	$body = sanitize_text_field( get_the_title( $post_id ) );
 
 	// Only if.
-	$text_override = get_auto_tweet_meta( $post_id, Meta\TWEET_BODY );
+	$text_override = get_autotweet_meta( $post_id, TWEET_BODY_KEY );
 	if ( ! empty( $text_override ) ) {
 		$body = $text_override;
 	}

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -29,10 +29,10 @@ function get_autotweet_meta( $id, $key ) {
 /**
  * Updates autotweet-related post metadata by prefixing the passed key.
  *
- * @param int    $id Post ID.
- * @param string $key Autotweet meta key.
+ * @param int    $id    Post ID.
+ * @param string $key   Autotweet meta key.
  * @param mixed  $value The meta value to save.
- * @return mixed meta_id if the meta doesn't exist, otherwise returns true on success and false on failure.
+ * @return mixed The meta_id if the meta doesn't exist, otherwise returns true on success and false on failure.
  */
 function update_autotweet_meta( $id, $key, $value ) {
 	return update_post_meta( $id, sprintf( '%s_%s', META_PREFIX, $key ), $value );

--- a/package-lock.json
+++ b/package-lock.json
@@ -830,6 +830,14 @@
         "@babel/plugin-transform-react-jsx-source": "^7.0.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+      "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "@babel/template": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
@@ -888,6 +896,33 @@
       "requires": {
         "any-observable": "^0.3.0"
       }
+    },
+    "@tannin/compile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.0.3.tgz",
+      "integrity": "sha512-OkPHvaM/hIHdSco3+ZO1hzkOtfEddn5a0veWft2aDLvKnbdj9VusiLKNdEE9by3hCZIIcb9aWF+iBorhfrQOfw==",
+      "requires": {
+        "@tannin/evaluate": "^1.1.1",
+        "@tannin/postfix": "^1.0.2"
+      }
+    },
+    "@tannin/evaluate": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.1.1.tgz",
+      "integrity": "sha512-ALuSZHjrLHGnw0WxsHDHde74FJ2WW0Ck4rg3QBxFBCmxd6Wsac+e0HXfJ++Qion15LIOCmFhyVpWzawMgeBA8Q=="
+    },
+    "@tannin/plural-forms": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.0.3.tgz",
+      "integrity": "sha512-IUr9+FiCnzCiB9aRio3FVNR8TNL9SmX2zkV6tmfWWwSclX4uTCykoGsDhTGKK+sZnMrdPCTmb/OxbtGNdVyV4g==",
+      "requires": {
+        "@tannin/compile": "^1.0.3"
+      }
+    },
+    "@tannin/postfix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.0.2.tgz",
+      "integrity": "sha512-Nggtk7/ljfNPpAX8CjxxLkMKuO6u2gH1ozmTvGclWF2pNcxTf6YGghYNYNWZRKrimXGhQ8yZqvAHep7h80K04g=="
     },
     "@types/events": {
       "version": "3.0.0",
@@ -1098,6 +1133,45 @@
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/wast-parser": "1.8.5",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "@wordpress/api-fetch": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.4.0.tgz",
+      "integrity": "sha512-aNLVIXlnn7RIEzbDcVFhyQfV60O0ggLQOCkHhMCW1Ya86Jlohp658TXe8wIjFhC2ugY239WeZIl1tgoRjqIr0A==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@wordpress/i18n": "^3.6.0",
+        "@wordpress/url": "^2.7.0"
+      }
+    },
+    "@wordpress/i18n": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.6.0.tgz",
+      "integrity": "sha512-/fkc5OoUCrIyHAaBEKIsXKl+UWj2kKjquhMSSHu3eVqLv/WKrKAzypPPAZC9UXfdSVBY8MrORYLh7vUy9Ic3Vw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "gettext-parser": "^1.3.1",
+        "lodash": "^4.17.14",
+        "memize": "^1.0.5",
+        "sprintf-js": "^1.1.1",
+        "tannin": "^1.1.0"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+        }
+      }
+    },
+    "@wordpress/url": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.7.0.tgz",
+      "integrity": "sha512-W1KEyllal8YWbLMyqfbPw7pQzVsJh73RQyqElrPwZ84TPeH/1JilKVMgKb2RXgJw8q8I+gZIXi6GmVY0+WNAxg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "qs": "^6.5.2"
       }
     },
     "@xtuc/ieee754": {
@@ -2437,6 +2511,14 @@
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
     },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -3741,6 +3823,15 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
+    "gettext-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+      "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+      "requires": {
+        "encoding": "^0.1.12",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
@@ -3991,7 +4082,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -4743,8 +4833,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "log-symbols": {
       "version": "3.0.0",
@@ -4845,6 +4934,11 @@
         "mimic-fn": "^2.0.0",
         "p-is-promise": "^2.0.0"
       }
+    },
+    "memize": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.0.5.tgz",
+      "integrity": "sha512-Dm8Jhb5kiC4+ynYsVR4QDXKt+o2dfqGuY4hE2x+XlXZkdndlT80bJxfcMv5QGp/FCy6MhG7f5ElpmKPFKOSEpg=="
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -5575,6 +5669,11 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "qs": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.8.0.tgz",
+      "integrity": "sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w=="
+    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -5777,6 +5876,11 @@
       "requires": {
         "regenerate": "^1.4.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regenerator-transform": {
       "version": "0.14.1",
@@ -6017,8 +6121,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -6032,8 +6135,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "schema-utils": {
       "version": "1.0.0",
@@ -6563,6 +6665,14 @@
             "ansi-regex": "^4.1.0"
           }
         }
+      }
+    },
+    "tannin": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tannin/-/tannin-1.1.0.tgz",
+      "integrity": "sha512-LxhcXqpMHEOVeVKmuG5aCPPsTXFlO373vrWkqN7FSJBVLS6lFOAg8ZGzIyGhrOf7Ho3xB4jdGedY1gi/8J1FCA==",
+      "requires": {
+        "@tannin/plural-forms": "^1.0.3"
       }
     },
     "tapable": {

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
 		"lint-staged": "^9.2.0",
 		"webpack": "^4.36.1",
 		"webpack-cli": "^3.3.6"
+	},
+	"dependencies": {
+		"@wordpress/api-fetch": "^3.4.0"
 	}
 }

--- a/src/js/externals/api-fetch.js
+++ b/src/js/externals/api-fetch.js
@@ -1,0 +1,3 @@
+import apiFetch from '@wordpress/api-fetch';
+
+wp.apiFetch = apiFetch;

--- a/tenup-auto-tweet.php
+++ b/tenup-auto-tweet.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+define( 'TUAT', __FILE__ );
 define( 'TUAT_VERSION', '0.1.0' );
 define( 'TUAT_URL', plugin_dir_url( __FILE__ ) );
 define( 'TUAT_PATH', plugin_dir_path( __FILE__ ) );

--- a/tests/phpunit/integration/TestRest.php
+++ b/tests/phpunit/integration/TestRest.php
@@ -76,7 +76,7 @@ class TestRest extends WP_UnitTestCase {
 		$this->assertEquals(
 			[
 				'enabled'  => true,
-				'message'  => 'Auto-tweet enabled.',
+				'message'  => 'Auto-tweet disabled.',
 				'override' => true,
 			],
 			$response->get_data()

--- a/tests/phpunit/integration/TestRest.php
+++ b/tests/phpunit/integration/TestRest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Tests rest.php
+ *
+ * @since 1.0.0
+ * @package TenUp\Auto_Tweet
+ */
+
+namespace TenUp\Auto_Tweet\Tests;
+
+use WP_REST_Request;
+use WP_UnitTestCase;
+use function TenUp\AutoTweet\REST\{
+	post_autotweet_meta_rest_route,
+	update_post_autotweet_meta_permission_check, 
+	update_post_autotweet_meta
+};
+use const TenUp\Auto_Tweet\Core\Post_Meta\ENABLE_AUTOTWEET_KEY;
+use const TenUp\Auto_Tweet\Core\Post_Meta\TWEET_BODY_KEY;
+
+/**
+ * TestRest class.
+ *
+ * @sincd 1.0.0
+ */
+class TestRest extends WP_UnitTestCase {
+	private function get_valid_request( $post = null ) {
+		if ( empty( $post ) ) {
+			$post = $this->factory->post->create();
+		}
+
+		$request = WP_REST_Request::from_url( rest_url( post_autotweet_meta_rest_route( $post ) ) );
+		$request->set_attributes( [ 'id' => $post ] );
+		$request->set_param( ENABLE_AUTOTWEET_KEY, true );
+		$request->set_param( TWEET_BODY_KEY, 'tweet override' );
+		return $request;
+	}
+
+	/**
+	 * Tests the post_autotweet_meta_rest_route function.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_post_autotweet_meta_rest_route() {
+		$this->assertEquals(
+			'autotweet/v1/post-autotweet-meta/999',
+			post_autotweet_meta_rest_route( 999 )
+		);
+
+		$this->assertEquals(
+			'autotweet/v1/post-autotweet-meta/9999',
+			post_autotweet_meta_rest_route( '9999' )
+		);
+	}
+
+	/**
+	 * Tests the update_post_autotweet_meta_permission_check function.
+	 *
+	 * @since 1.0.0
+	 */
+	public function _test_update_post_autotweet_meta_permission_check() {
+		wp_set_current_user( $this->factory->user->create() );
+		$this->assertFalse( update_post_autotweet_meta_permission_check( $this->get_valid_request() ) );
+
+		wp_set_current_user( 1 ); // Administrator user.
+		$this->assertTrue( update_post_autotweet_meta_permission_check( $this->get_valid_request() ) );
+	}
+	
+	/**
+	 * Tests the update_post_autotweet_meta function.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_update_post_autotweet_meta() {
+		$response = update_post_autotweet_meta( $this->get_valid_request() );
+		$this->assertEquals(
+			[
+				'enabled'  => true,
+				'message'  => 'Auto-tweet enabled.',
+				'override' => true,
+			],
+			$response->get_data()
+		);
+
+	}
+}

--- a/tests/phpunit/integration/TestUtils.php
+++ b/tests/phpunit/integration/TestUtils.php
@@ -9,7 +9,7 @@
 namespace TenUp\Auto_Tweet\Tests;
 
 use \WP_UnitTestCase;
-use function TenUp\Auto_Tweet\Utils\{get_auto_tweet_meta, opted_into_autotweet};
+use function TenUp\Auto_Tweet\Utils\{get_autotweet_meta, opted_into_autotweet, update_autotweet_meta, delete_autotweet_meta};
 use const TenUp\Auto_Tweet\Core\Post_Meta\META_PREFIX;
 
 /**
@@ -20,18 +20,44 @@ use const TenUp\Auto_Tweet\Core\Post_Meta\META_PREFIX;
 class TestUtils extends WP_UnitTestCase {
 
 	/**
-	 * Tests the get_auto_tweet_meta utility function.
+	 * Tests the get_autotweet_meta utility function.
 	 *
 	 * @since 1.0.0
 	 */
-	public function test_get_auto_tweet_meta() {
+	public function test_get_autotweet_meta() {
 		$post = $this->factory->post->create();
 
-		$this->assertEquals( null, get_auto_tweet_meta( $post, 'some-key' ) );
+		$this->assertEquals( null, get_autotweet_meta( $post, 'some-key' ) );
 
 		update_post_meta( $post, sprintf( '%s_%s', META_PREFIX, 'some-key' ), 'some-data' );
 
-		$this->assertEquals( 'some-data', get_auto_tweet_meta( $post, 'some-key' ) );
+		$this->assertEquals( 'some-data', get_autotweet_meta( $post, 'some-key' ) );
+	}
+
+	/**
+	 * Tests the update_autotweet_meta utility function.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_update_autotweet_meta() {
+		$post = $this->factory->post->create();
+		update_autotweet_meta( $post, 'some-update-key', 1234 );
+
+		$this->assertEquals( 1234, get_post_meta( $post, sprintf( '%s_%s', META_PREFIX, 'some-update-key' ), true ) );
+	}
+
+	/**
+	 * Tests the delete_autotweet_meta utility function.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_delete_autotweet_meta() {
+		$post = $this->factory->post->create();
+		update_post_meta( $post, sprintf( '%s_%s', META_PREFIX, 'some-delete-key' ), '4321' );
+
+		delete_autotweet_meta( $post, 'some-delete-key' );
+
+		$this->assertFalse( metadata_exists( 'post', $post, sprintf( '%s_%s', META_PREFIX, 'some-delete-key' ) ) );
 	}
 
 	/**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const path = require('path');
 module.exports = {
 	entry: {
 		autotweet: './src/js/index.js',
+		'api-fetch': './src/js/externals/api-fetch'
 	},
 	module: {
 		rules: [


### PR DESCRIPTION
This is intended to resolve #14 . ~~It depends on #29~~ (Merged)

### Description of the Change

#### REST endpoint
The current version of the plugin uses an AJAX handler to save the metadata that determines whether a post will be tweeted and whether the default autotweet content will be overridden.

This update removes the AJAX handler in favor of a custom REST endpoint. The endpoint is simple, accepting a POST request with three required fields (post ID, whether autotweet is enabled, and override content). Permission on the REST endpoint is set to check that the current user can edit the post. After the data is successfully saved, the REST endpoint sends back details about the data that was saved.

I also updated the JS file that handles the autotweet feature in the classic editor. It's now hooked up the REST endpoint instead of the AJAX endpoint.

#### Post meta updates

While setting up the REST endpoint, I did a minor refactor of some details around how post meta is handled. There was already a `get_autotweet_meta` function that wraps `get_post_meta` with a prefix on the meta key, and I created equivalents for updating and deleting meta. I also renamed some of the meta-related constants and used them in several places where the values were hardcoded. And I used the meta keys as the required parameters in the REST endpoint for clarity and consistency.

**Note: ** I changed the meta prefix to use `autotweet` instead of `auto-tweet`, and changed one of the meta keys to make it more descriptive. This will break backward-compatibility if the current version of this plugin is being used anywhere. Could that be an issue? If so, I will switch it back to what it was.

### What this does not do

Although I modified the existing JS file to use the REST endpoint instead of AJAX -- and some ESLinting was applied to the file -- I stopped there. That JS file could easily be refactored to remove the jQuery dependency and use ES6 (via the Webpack config), but I considered that out of scope.

### Alternative designs

I considered adding autotweet-related metadata as REST fields, eliminating the need for the REST endpoint. But with that approach, the autotweet data would be included in all REST responses for the supported posts, which probably isn't useful anywhere outside this plugin's narrow set of features.

### Verification Process

Confirm that the integration with the classic editor still works as expected. It now runs through the REST API rather than AJAX.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my change.
- [X] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

