### PR TITLE
update formatting for dotorg display of readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Autoshare for Twitter ===
-Contributors:      10up
-Tags:              twitter, tweet, autoshare, auto-share, share, social media
+Contributors:      10up, johnwatkins0, adamsilverstein
+Tags:              twitter, tweet, autoshare, auto-share, auto share, share, social media
 Requires at least: 4.7
-Tested up to:      5.3
+Tested up to:      5.3.2
 Requires PHP:      7.0
 Stable tag:        1.0.0
 License:           GPL-2.0-or-later
@@ -21,24 +21,24 @@ Automatically tweets the post title or custom message and a link to the post.
 == Manual Installation ==
 1. Upload the entire `/autoshare-for-twitter` directory to the `/wp-content/plugins/` directory.
 2. Activate the plugin
-3. Register post type support for types that should be allowed to autoshare. `add_post_type_support( 'post', 'autoshare-for-twitter' );`
+3. Register post type support for types that should be allowed to autoshare: `add_post_type_support( 'post', 'autoshare-for-twitter' );`
 
 == FAQs ==
-Does this plugin work with Gutenberg?
-Yes, yes it does!  For more details on this, see #44.
+= Does this plugin work with Gutenberg? =
+Yes, yes it does!  For more details on this, see [#44](https://github.com/10up/autoshare-for-twitter/pull/44).
 
 == Changelog ==
 
 = 1.0.0 =
 * **Added:** Initial public release! 🎉
 * **Added:** Plugin renamed to "Autoshare for Twitter"
-* **Added:** Support Post and Page post types by default, provide Custom Post Type (props @johnwatkins0)
-* **Added:** Gutenberg support (props @johnwatkins0)
-* **Added:** REST API endpoint to replace AJAX callback (props @johnwatkins0)
-* **Added:** Build process, PHPCS linting, unit tests, and Travis CI (props @johnwatkins0, @adamsilverstein)
+* **Added:** Support Post and Page post types by default, provide Custom Post Type (props [@johnwatkins0](https://profiles.wordpress.org/johnwatkins0/))
+* **Added:** Gutenberg support (props [@johnwatkins0](https://profiles.wordpress.org/johnwatkins0/))
+* **Added:** REST API endpoint to replace AJAX callback (props [@johnwatkins0](https://profiles.wordpress.org/johnwatkins0/))
+* **Added:** Build process, PHPCS linting, unit tests, and Travis CI (props [@johnwatkins0](https://profiles.wordpress.org/johnwatkins0/), [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/))
 * **Added:** Plugin banner and icon images (props Stephanie Campbell)
-* **Changed:** Refactor v0.1.0 significantly (props @adamsilverstein, @johnwatkins0, @jeffpaul)
-* **Security:** XSS prevention - switch from .innerHTML to text (props @adamsilverstein)
+* **Changed:** Refactor v0.1.0 significantly (props [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/), [@johnwatkins0](https://profiles.wordpress.org/johnwatkins0/), [@jeffpaul](https://profiles.wordpress.org/jeffpaul/))
+* **Security:** XSS prevention - switch from .innerHTML to text (props [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/))
 
 = 0.1.0 =
 * Initial private release


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

As I was adding back icon and banner images I noticed that the text display on .ORG also looked "off".  This updates some of the text formatting for nicer display on .ORG.  Also adds @johnwatkins0 and @adamsilverstein as contributors for the .ORG display (not sure how they were left off to begin with).

### Alternate Designs

Keep as-is?

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

none identified

### Verification Process

Manually verified via the GitHub web UI.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

None, mea culpa 😬 

### Changelog Entry

n/a
