### PR TITLE
Avoid get_the_title texturization when auto-composing tweet

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -232,8 +232,10 @@ function already_published( $post_id ) {
  * @return string
  */
 function get_tweet_body( $post_id ) {
-
-	$body = sanitize_text_field( get_the_title( $post_id ) );
+	// Use $post->post_title instead of get_the_title( $post_id ) because the latter may introduce texturized characters
+	// that Twitter won't decode.
+	$post = get_post( $post_id );
+	$body = sanitize_text_field( $post->post_title );
 
 	// Only if.
 	$text_override = get_autoshare_for_twitter_meta( $post_id, TWEET_BODY_KEY );


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

This would close #72 .

@rickalee Discovered that some undecoded special characters (hyphens/dashes and quotation marks, specifically) were appearing in tweets generated by this plugin. On closer inspection, I found that the WP core function `get_the_title` was being used to generate the tweet body. That function applies several filters, one of which (unless overridden) is [`wptexturize`](https://developer.wordpress.org/reference/functions/wptexturize/). This is where the characters were coming from.

To fix it, I removed `get_the_title` in favor of accessing `post_title` from the WP post object directly.

This issue only occurred when the post title was tweeted, not when custom share text was entered.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

We could alternatively continue to use `get_the_title` and selectively disable only [the default filters ](https://github.com/WordPress/WordPress/blob/master/wp-includes/default-filters.php) causing the character issues. In this scenario, though, we would need to immediately re-add any removed filters to avoid causing side effects elsewhere, and this could become complicated. Probably not worth the effort.

### Benefits

<!-- What benefits will be realized by the code change? -->

Characters in Tweets appear as expected.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

Create a post whose title contains dashes and quotation marks. Turn on autosharing for the post. Publish the post. Verify that the characters appear as expected.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

Resolves #72

### Changelog Entry

Bypass character texturization when the post title is tweeted