### PR TITLE
Save autoshare meta from post form before publishing tweet

### DIFF
--- a/includes/admin/post-meta.php
+++ b/includes/admin/post-meta.php
@@ -60,7 +60,20 @@ function setup() {
  * @return void
  */
 function save_tweet_meta( $post_id, $post = null, $update = true ) {
-	if ( ! $update || ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || ! current_user_can( 'edit_post', $post_id ) ) {
+	if ( ! $update ) {
+		return;
+	}
+
+	// Meta is saved in a separate request in the block editor.
+	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+		return;
+	}
+
+	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+		return;
+	}
+
+	if ( ! current_user_can( 'edit_post', $post_id ) ) {
 		return;
 	}
 
@@ -121,13 +134,12 @@ function sanitize_autoshare_for_twitter_meta_data( $data ) {
  * @param array $data Associative array of data to save.
  */
 function save_autoshare_for_twitter_meta_data( $post_id, $data ) {
-
 	if ( ! is_array( $data ) ) {
 		$data = [];
 	}
 
 	// If the enable key is not set, it should be turned off.
-	if ( ! isset( $data[ ENABLE_AUTOSHARE_FOR_TWITTER_KEY ] ) ) {
+	if ( ! array_key_exists( ENABLE_AUTOSHARE_FOR_TWITTER_KEY, $data ) ) {
 		$data[ ENABLE_AUTOSHARE_FOR_TWITTER_KEY ] = 0;
 	}
 

--- a/includes/admin/post-meta.php
+++ b/includes/admin/post-meta.php
@@ -64,12 +64,26 @@ function save_tweet_meta( $post_id, $post = null, $update = true ) {
 		return;
 	}
 
-	$form_data = sanitize_autoshare_for_twitter_meta_data(
-		// Using FILTER_DEFAULT here as data is being passed to sanitize function.
-		filter_input( INPUT_POST, META_PREFIX, FILTER_DEFAULT, FILTER_REQUIRE_ARRAY )
-	);
+	$form_data = sanitize_autoshare_for_twitter_meta_data( get_autoshare_post_form_data() );
 
 	save_autoshare_for_twitter_meta_data( $post_id, $form_data );
+}
+
+/**
+ * Provides data passed from the post editor form.
+ *
+ * @return array
+ */
+function get_autoshare_post_form_data() {
+	// Using FILTER_DEFAULT here as data is being passed to sanitize function.
+	$data = filter_input( INPUT_POST, META_PREFIX, FILTER_DEFAULT, FILTER_REQUIRE_ARRAY );
+
+	/**
+	 * Filters data received from the post form.
+	 *
+	 * @param array $data
+	 */
+	return apply_filters( 'autoshare_post_form_data', $data );
 }
 
 /**

--- a/includes/admin/post-transition.php
+++ b/includes/admin/post-transition.php
@@ -12,6 +12,7 @@ use TenUp\AutoshareForTwitter\Core\Post_Meta as Meta;
 use TenUp\AutoshareForTwitter\Utils as Utils;
 use function TenUp\AutoshareForTwitter\Utils\delete_autoshare_for_twitter_meta;
 use function TenUp\AutoshareForTwitter\Utils\update_autoshare_for_twitter_meta;
+use function TenUp\AutoshareForTwitter\Core\Post_Meta\save_tweet_meta;
 
 /**
  * Setup function.
@@ -45,6 +46,9 @@ function maybe_publish_tweet( $new_status, $old_status, $post ) {
 	if ( 'publish' !== $new_status || 'publish' === $old_status ) {
 		return;
 	}
+
+	// Ensure Autoshare-related form data is saved before reaching the publish_tweet step.
+	save_tweet_meta( $post->ID );
 
 	/**
 	 * Don't bother enqueuing assets if the post type hasn't opted into autosharing

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -16,7 +16,7 @@ use const TenUp\AutoshareForTwitter\Core\POST_TYPE_SUPPORT_FEATURE;
 
 use function TenUp\AutoshareForTwitter\Core\Post_Meta\get_tweet_status_message;
 use function TenUp\AutoshareForTwitter\Core\Post_Meta\save_autoshare_for_twitter_meta_data;
-
+use function TenUp\AutoshareForTwitter\Utils\get_autoshare_for_twitter_meta;
 
 /**
  * The namespace for plugin REST endpoints.
@@ -122,15 +122,17 @@ function update_post_autoshare_for_twitter_meta( $request ) {
 	$params = $request->get_params();
 
 	save_autoshare_for_twitter_meta_data( $request['id'], $params );
-	$message = 1 === $params[ ENABLE_AUTOSHARE_FOR_TWITTER_KEY ] ?
+
+	$enabled = (bool) get_autoshare_for_twitter_meta( $request['id'], ENABLE_AUTOSHARE_FOR_TWITTER_KEY, true );
+	$message = $enabled ?
 		__( 'Autoshare enabled.', 'autoshare-for-twitter' ) :
 		__( 'Autoshare disabled.', 'autoshare-for-twitter' );
 
 	return rest_ensure_response(
 		[
-			'enabled'  => $params[ ENABLE_AUTOSHARE_FOR_TWITTER_KEY ],
+			'enabled'  => $enabled,
 			'message'  => $message,
-			'override' => ! empty( $params[ TWEET_BODY_KEY ] ),
+			'override' => ! empty( get_autoshare_for_twitter_meta( $request['id'], TWEET_BODY_KEY, true ) ),
 		]
 	);
 }

--- a/languages/autoshare-for-twitter.pot
+++ b/languages/autoshare-for-twitter.pot
@@ -1,40 +1,134 @@
+# Copyright (C) 2020 10up
+# This file is distributed under the GPL-2.0-or-later.
 msgid ""
 msgstr ""
+"Project-Id-Version: Autoshare for Twitter 1.0.1\n"
+"Report-Msgid-Bugs-To: "
+"https://wordpress.org/support/plugin/autoshare-for-twitter\n"
+"POT-Creation-Date: 2020-02-20 16:54:31+00:00\n"
+"MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
-"X-Generator: babel-plugin-makepot\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2020-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"X-Generator: node-wp-i18n 1.2.3\n"
 
-#: src/js/AutoshareForTwitterPostStatusInfo.js:16
+#: includes/admin/assets.php:168
+msgid "Error"
+msgstr ""
+
+#: includes/admin/assets.php:173
+msgid "An unknown error occurred"
+msgstr ""
+
+#: includes/admin/post-meta.php:217 includes/admin/post-meta.php:270
+msgid "This post was not tweeted."
+msgstr ""
+
+#: includes/admin/post-meta.php:254
+#. Translators: Placeholder is a date.
+msgid "Tweeted on %s"
+msgstr ""
+
+#: includes/admin/post-meta.php:260
+msgid "Failed to tweet: "
+msgstr ""
+
+#: includes/admin/post-meta.php:294
+msgid "Tweeted on"
+msgstr ""
+
+#: includes/admin/post-meta.php:297
 msgid "View"
 msgstr ""
 
-#: src/js/AutoshareForTwitterPrePublishPanel.js:106
-msgid "Tweet this post?"
+#: includes/admin/post-meta.php:313
+msgid "Failed to tweet"
 msgstr ""
 
-#: src/js/AutoshareForTwitterPrePublishPanel.js:126
-msgid "Custom message:"
+#: includes/admin/post-meta.php:348
+msgid "Tweet this post"
 msgstr ""
 
-#: src/js/AutoshareForTwitterPrePublishPanel.js:141
-msgid "Hide"
-msgstr ""
-
-#: src/js/AutoshareForTwitterPrePublishPanel.js:141
+#: includes/admin/post-meta.php:349
 msgid "Edit"
 msgstr ""
 
-#: src/js/AutoshareForTwitterPrePublishPanel.js:63
-msgid "An error occurred."
+#: includes/admin/post-meta.php:354
+msgid "Custom Message"
 msgstr ""
 
-#: src/js/index.js:32
-msgid "Enabled"
+#: includes/admin/post-transition.php:144
+msgid "Something happened during Twitter update."
 msgstr ""
 
-#: src/js/index.js:32
-msgid "Disabled"
+#: includes/admin/post-transition.php:180
+msgid "This post was not published to Twitter."
 msgstr ""
 
-#: src/js/index.js:46
-msgid "Autoshare:"
+#. Plugin Name of the plugin/theme
+msgid "Autoshare for Twitter"
+msgstr ""
+
+#: includes/admin/settings.php:50
+msgid "Twitter Credentials"
+msgstr ""
+
+#: includes/admin/settings.php:58
+msgid "API key"
+msgstr ""
+
+#: includes/admin/settings.php:68
+msgid "API secret"
+msgstr ""
+
+#: includes/admin/settings.php:78
+msgid "Access token"
+msgstr ""
+
+#: includes/admin/settings.php:88
+msgid "Access secret"
+msgstr ""
+
+#: includes/admin/settings.php:98
+msgid "Twitter handle"
+msgstr ""
+
+#: includes/rest.php:67
+msgid "Unique identifier for the object."
+msgstr ""
+
+#: includes/rest.php:74
+msgid "Tweet text, if overriding the default"
+msgstr ""
+
+#: includes/rest.php:81
+msgid "Whether autoshare is enabled for the current post"
+msgstr ""
+
+#: includes/rest.php:128
+msgid "Autoshare enabled."
+msgstr ""
+
+#: includes/rest.php:129
+msgid "Autoshare disabled."
+msgstr ""
+
+#: includes/rest.php:157
+msgid "Autoshare status message"
+msgstr ""
+
+#. Description of the plugin/theme
+msgid ""
+"Automatically tweets the post title or custom message and a link to the "
+"post."
+msgstr ""
+
+#. Author of the plugin/theme
+msgid "10up"
+msgstr ""
+
+#. Author URI of the plugin/theme
+msgid "https://10up.com"
 msgstr ""

--- a/tests/phpunit/integration/TestPostMeta.php
+++ b/tests/phpunit/integration/TestPostMeta.php
@@ -10,7 +10,6 @@ namespace TenUp\AutoshareForTwitter\Tests;
 
 use WP_UnitTestCase;
 
-use const TenUp\AutoshareForTwitter\Core\Admin\AT_SETTINGS;
 use const TenUp\AutoshareForTwitter\Core\Post_Meta\ENABLE_AUTOSHARE_FOR_TWITTER_KEY;
 use const TenUp\AutoshareForTwitter\Core\Post_Meta\TWEET_BODY_KEY;
 use const TenUp\AutoshareForTwitter\Core\Post_Meta\TWITTER_STATUS_KEY;

--- a/tests/phpunit/integration/TestPostMeta.php
+++ b/tests/phpunit/integration/TestPostMeta.php
@@ -11,14 +11,20 @@ namespace TenUp\AutoshareForTwitter\Tests;
 use WP_UnitTestCase;
 
 use const TenUp\AutoshareForTwitter\Core\Admin\AT_SETTINGS;
+use const TenUp\AutoshareForTwitter\Core\Post_Meta\ENABLE_AUTOSHARE_FOR_TWITTER_KEY;
+use const TenUp\AutoshareForTwitter\Core\Post_Meta\TWEET_BODY_KEY;
 use const TenUp\AutoshareForTwitter\Core\Post_Meta\TWITTER_STATUS_KEY;
 
 use function TenUp\AutoshareForTwitter\Core\Post_Meta\get_tweet_status_message;
+use function TenUp\AutoshareForTwitter\Core\Post_Meta\save_autoshare_for_twitter_meta_data;
+use function TenUp\AutoshareForTwitter\Utils\get_autoshare_for_twitter_meta;
 
 /**
  * TestUtils class.
  *
  * @sincd 1.0.0
+ *
+ * @group post_meta
  */
 class TestPostMeta extends WP_UnitTestCase {
 	/**
@@ -32,7 +38,7 @@ class TestPostMeta extends WP_UnitTestCase {
 			get_tweet_status_message( -1 )
 		);
 
-		$post = $this->factory->post->create( [ 'status' => 'publish' ] );
+		$post = $this->factory->post->create( [ 'post_status' => 'publish' ] );
 
 		$published_filter = function( $data, $id, $key ) use ( $post ) {
 			if ( intval( $post ) === intval( $id ) && TWITTER_STATUS_KEY === $key ) {
@@ -112,4 +118,57 @@ class TestPostMeta extends WP_UnitTestCase {
 		remove_filter( 'autoshare_for_twitter_meta', $other_filter );
 	}
 
+	/**
+	 * Provides test data.
+	 *
+	 * @return array
+	 */
+	public function save_autoshare_for_twitter_meta_data_provider() {
+		return [
+			[
+				// Test autoshare is disabled when no data is passed.
+				[ 'post_status' => 'publish' ],
+				[],
+				false,
+			],
+			[
+				// Test autoshare is disabled when false is passed.
+				[ 'post_status' => 'publish' ],
+				[ ENABLE_AUTOSHARE_FOR_TWITTER_KEY => '0' ],
+				false,
+			],
+			[
+				// Test autoshare is disabled when only a tweet body is passed.
+				[ 'post_status' => 'publish' ],
+				[ TWEET_BODY_KEY => 'my cool tweet' ],
+				false,
+			],
+			[
+				// Test autoshare is enabled when true is passed.
+				[ 'post_status' => 'publish' ],
+				[ ENABLE_AUTOSHARE_FOR_TWITTER_KEY => '1' ],
+				true,
+			],
+		];
+	}
+
+	/**
+	 * Tests the save_autoshare_for_twitter_meta_data function.
+	 *
+	 * @dataProvider save_autoshare_for_twitter_meta_data_provider
+	 *
+	 * @param array   $args Create post args.
+	 * @param array   $data Meta data to save.
+	 * @param boolean $expected Expecte result.
+	 */
+	public function test_save_autoshare_for_twitter_meta_data( $args, $data, $expected ) {
+		$id = $this->factory->post->create( $args );
+		save_autoshare_for_twitter_meta_data( $id, $data );
+
+		if ( $expected ) {
+			$this->assertTrue( (bool) get_autoshare_for_twitter_meta( $id, ENABLE_AUTOSHARE_FOR_TWITTER_KEY ) );
+		} else {
+			$this->assertFalse( (bool) get_autoshare_for_twitter_meta( $id, ENABLE_AUTOSHARE_FOR_TWITTER_KEY ) );
+		}
+	}
 }

--- a/tests/phpunit/integration/TestPostTransition.php
+++ b/tests/phpunit/integration/TestPostTransition.php
@@ -11,9 +11,7 @@ namespace TenUp\AutoshareForTwitter\Tests;
 use WP_UnitTestCase;
 
 use const TenUp\AutoshareForTwitter\Core\Post_Meta\ENABLE_AUTOSHARE_FOR_TWITTER_KEY;
-use const TenUp\AutoshareForTwitter\Core\Post_Meta\TWITTER_STATUS_KEY;
 
-use function TenUp\AutoshareForTwitter\Core\Post_Meta\get_tweet_status_message;
 use function TenUp\AutoshareForTwitter\Core\Post_Transition\maybe_publish_tweet;
 
 /**

--- a/tests/phpunit/integration/TestPostTransition.php
+++ b/tests/phpunit/integration/TestPostTransition.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Tests functions admin/post-meta.php.
+ *
+ * @since 1.0.0
+ * @package TenUp\AutoshareForTwitter
+ */
+
+namespace TenUp\AutoshareForTwitter\Tests;
+
+use WP_UnitTestCase;
+
+use const TenUp\AutoshareForTwitter\Core\Post_Meta\ENABLE_AUTOSHARE_FOR_TWITTER_KEY;
+use const TenUp\AutoshareForTwitter\Core\Post_Meta\TWITTER_STATUS_KEY;
+
+use function TenUp\AutoshareForTwitter\Core\Post_Meta\get_tweet_status_message;
+use function TenUp\AutoshareForTwitter\Core\Post_Transition\maybe_publish_tweet;
+
+/**
+ * TestPostTransition
+ *
+ * @group post_transition
+ *
+ * @sincd 1.0.0
+ */
+class TestPostTransition extends WP_UnitTestCase {
+	/**
+	 * Setup.
+	 */
+	public function setUp() {
+		wp_set_current_user( 1 );
+
+		parent::setUp();
+	}
+
+	/**
+	 * Provides test data.
+	 *
+	 * @return array
+	 */
+	public function maybe_publish_tweet_provider() {
+		return [
+			[
+				// Post transitioning from publish to draft should not tweet.
+				[ 'post_status' => 'publish' ],
+				'1',
+				'draft',
+				'publish',
+				false,
+			],
+			[
+				// Already-published post should not tweet.
+				[ 'post_status' => 'publish' ],
+				'1',
+				'publish',
+				'publish',
+				false,
+			],
+			[
+				// Post transitioning from draft to publish should tweet if autotweet_enabled is true.
+				[
+					'post_status' => 'draft',
+					'post_title'  => 'TEST',
+					'post_author' => 1,
+				],
+				'1',
+				'publish',
+				'draft',
+				true,
+			],
+			[
+				// Post transitioning from draft to publish should not tweet if autotweet is not true.
+				[ 'post_status' => 'draft' ],
+				'0',
+				'publish',
+				'draft',
+				false,
+			],
+		];
+	}
+
+	/**
+	 * Tests the maybe_publish_tweet function.
+	 *
+	 * @dataProvider maybe_publish_tweet_provider
+	 *
+	 * @param array   $post_args Args to pass to the create post function.
+	 * @param boolean $autoshare_enabled_form_data Updated autoshare enabled meta value.
+	 * @param string  $new_status The new post status.
+	 * @param string  $old_status The old post status.
+	 * @param boolean $expected_should_tweet Whether the post should be tweeted.
+	 */
+	public function test_maybe_publish_tweet(
+		$post_args,
+		$autoshare_enabled_form_data,
+		$new_status,
+		$old_status,
+		$expected_should_tweet
+	) {
+		$the_post                   = $this->factory->post->create_and_get( $post_args );
+		$post_was_tweeted           = false;
+		$pre_status_update_callback = function() use ( &$post_was_tweeted ) {
+			$post_was_tweeted = true;
+
+			// Minimum valid response.
+			return (object) [
+				'id'         => 1,
+				'created_at' => time(),
+			];
+		};
+		add_filter( 'autoshare_for_twitter_pre_status_update', $pre_status_update_callback );
+
+		$post_form_data_callback = function() use ( $autoshare_enabled_form_data ) {
+			return [ ENABLE_AUTOSHARE_FOR_TWITTER_KEY => $autoshare_enabled_form_data ];
+		};
+		add_filter( 'autoshare_post_form_data', $post_form_data_callback );
+
+		maybe_publish_tweet( $new_status, $old_status, $the_post );
+
+		if ( $expected_should_tweet ) {
+			$this->assertTrue( $post_was_tweeted );
+		} else {
+			$this->assertFalse( $post_was_tweeted );
+		}
+
+		remove_filter( 'autoshare_for_twitter_pre_status_update', $pre_status_update_callback );
+		remove_filter( 'autoshare_post_form_data', $post_form_data_callback );
+	}
+}

--- a/tests/phpunit/integration/TestRest.php
+++ b/tests/phpunit/integration/TestRest.php
@@ -96,7 +96,7 @@ class TestRest extends WP_UnitTestCase {
 		$this->assertEquals(
 			[
 				'enabled'  => true,
-				'message'  => 'Autoshare disabled.',
+				'message'  => 'Autoshare enabled.',
 				'override' => true,
 			],
 			$response->get_data()


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This resolves a bug brought up by @rickalee  in #80. Autoshare form data is saved in `save_post` while the tweet action runs on `transition_post_status`. `transition_post_status` runs earlier than `save_post`, so the bug happened in the case where:

1) The post is switching from from a non-publish status to publish
2) AND the autoshare status is switching from enabled to disabled.

In this case, the enabled status has not been saved before the tweet function runs, so the post is tweeted.

This update causes the form data to be processed before trying to tweet.

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

I'm wanting to refactor large parts of this plugin, but I'm holding for now and will aim to submit issues outlining the specific technical debt I'm seeing.

### Benefits

<!-- What benefits will be realized by the code change? -->

Tweets won't be inadvertently published during the specific scenario outlined above.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

1. Create a new post
2. Leave 'Tweet this Post' checked
3. Save Draft
4. Uncheck 'Tweet this Post'
5. Save Draft/Publish
6. Post should **not** be tweeted

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

Resolves #80 

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

Fix a bug that caused posts to be inadvertently tweeted when switching from draft to publish
