### PR TITLE
Don't exclude vendor directory during plugin deploy action

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -10,14 +10,6 @@
 /bin
 /phpunit.xml
 
-# Exclude vendor folder, except required dependencies.
-/vendor
-!/vendor/composer
-!/vendor/autoload.php
-!/vendor/abraham
-!/vendor/symfony
-!/vendor/myclabs
-
 # Files
 .babelrc
 .distignore


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

This resolves #94. The lines removed by this PR caused the `vendor` directory to be ignored in a recent plugin release for reasons described in that issue. We can safely remove these lines from `.distignore` because in the deploy workflow we only install production Composer dependencies: https://github.com/10up/autoshare-for-twitter/blob/develop/.github/workflows/deploy-to-wpdotorg.yml#L17

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

The deploy action will work as expected 😅 

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

This cannot be easily verified until the next release. While I expect the fix to work, we should monitor the deploy action on the next release and be prepared to test, then fix any issues immediately.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

#94 

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

Removed lines from `.distignore` that caused issue during automated plugin deploy
