### PR TITLE
bump WP tested-up-to version 5.7 on `trunk`

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      10up, johnwatkins0, adamsilverstein, scottlee, dinhtungdu
 Tags:              twitter, tweet, autoshare, auto-share, auto share, share, social media
 Requires at least: 4.7
-Tested up to:      5.4.2
+Tested up to:      5.7
 Requires PHP:      7.0
 Stable tag:        1.0.4
 License:           GPL-2.0-or-later
@@ -15,8 +15,6 @@ Automatically tweets the post title or custom message and a link to the post.
 Automatically tweets the post title or custom message and a link to the post.
 
 **Disclaimer:** *TWITTER, TWEET, RETWEET and the Twitter logo are trademarks of Twitter, Inc. or its affiliates.*
-
-**Note:** Post types are automatically set to autoshare. Future versions of this plugin could allow this to be set manually.
 
 == Manual Installation ==
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR relates to #126 in pushing the readme.txt update to `trunk` to (hopefully) engage the GitHub Action to push the change across to WP.org SVN.

### Alternate Designs

n/a

### Benefits

Ensures we correctly show the WordPress "tested up to" version on WP.org.

### Possible Drawbacks

None identified.

### Verification Process

Manually verified via VS Code.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Relates to #110.

### Changelog Entry

n/a
