### PR TITLE
Fix: failed wp.org deployment

### DIFF
--- a/.github/workflows/deploy-to-wpdotorg.yml
+++ b/.github/workflows/deploy-to-wpdotorg.yml
@@ -14,7 +14,7 @@ jobs:
         npm install
         npm run build
         npm run build:externals
-        composer install -o --no-dev
+        composer install -o --no-dev --ignore-platform-reqs
     - name: WordPress Plugin Deploy
       id: deploy
       uses: 10up/action-wordpress-plugin-deploy@stable


### PR DESCRIPTION

<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
We're using `abraham/twitteroauth` `1.2.0` which requires PHP `7.x`. The PHP version shipped with Ubuntu latest (20.04.3 LTS at the time of writing) is PHP `8.0`. That's why `composer` throws the requirement errors. This commit fixes that issue by using `--ignore-platform-reqs` flag to bypass the requirement check. However, the best way to solve this issue is to upgrade the library version to a more recent version.

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs
We can use an older version of Ubuntu or install PHP `7.x`. But that means we need to comeback in the future when those older versions are dropped. Using `--ignore-platform-reqs` at least give us a cue to verify the build is passed with the recent versions of OS and PHP.
<!-- Explain what other alternates were considered and why the proposed version was selected. -->