### PR TITLE
fix/154: Fix autotweet when autoshare enabled by default.

### DIFF
--- a/includes/admin/post-meta.php
+++ b/includes/admin/post-meta.php
@@ -146,11 +146,7 @@ function save_autoshare_for_twitter_meta_data( $post_id, $data ) {
 	foreach ( $data as $key => $value ) {
 		switch ( $key ) {
 			case ENABLE_AUTOSHARE_FOR_TWITTER_KEY:
-				if ( ! empty( $value ) ) {
-					update_autoshare_for_twitter_meta( $post_id, ENABLE_AUTOSHARE_FOR_TWITTER_KEY, $value );
-				} else {
-					delete_autoshare_for_twitter_meta( $post_id, ENABLE_AUTOSHARE_FOR_TWITTER_KEY );
-				}
+				update_autoshare_for_twitter_meta( $post_id, ENABLE_AUTOSHARE_FOR_TWITTER_KEY, $value );
 				break;
 
 			case TWEET_BODY_KEY:


### PR DESCRIPTION
### Description of the Change
This PR contains changes for fixing autotweet when autoshare is enabled by default.

This bug is introduced with [this change](https://github.com/10up/autoshare-for-twitter/pull/145/files#diff-1070213f6f129a08b5ab3c549e5ec0554d4380f0cfaa40d0fbfcfa224f3b1458R149-R153) of PR #145 and this PR rollback it to fix given issue.
<!-- Enter any applicable Issues here. Example: -->
Closes #154

### Verification Process
Manually test fix by reproducing steps given [here](https://github.com/10up/autoshare-for-twitter/issues/154#issue-1203301015) 

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry
Fixed - If Autoshare is enabled by default, it does not consider the post-level "Tweet this post" checkbox and always tweets.
<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @
