### PR TITLE
Handle publish tweet from staging/testing site.

### DIFF
--- a/includes/admin/post-transition.php
+++ b/includes/admin/post-transition.php
@@ -65,7 +65,7 @@ function maybe_publish_tweet( $new_status, $old_status, $post ) {
 	/**
 	 * Don't publish tweets from staging/testing sites.
 	 */
-	if ( AST_Staging::is_duplicate_site() ) {
+	if ( ! AST_Staging::is_production_site() ) {
 		return;
 	}
 
@@ -104,7 +104,7 @@ function publish_tweet( $post_id ) {
 	/**
 	 * Don't publish tweets from staging/testing sites.
 	 */
-	if ( AST_Staging::is_duplicate_site() ) {
+	if ( ! AST_Staging::is_production_site() ) {
 		return;
 	}
 

--- a/includes/admin/post-transition.php
+++ b/includes/admin/post-transition.php
@@ -41,30 +41,28 @@ function setup() {
  * @return object
  */
 function maybe_publish_tweet( $new_status, $old_status, $post ) {
-	/**
+	/*
 	 * Add filter to return early based on post or status
 	 */
 	if ( apply_filters( 'autoshare_for_twitter_disable_on_transition_post_status', false, $post, $old_status, $new_status ) ) {
 		return;
 	}
 
-	/**
+	/*
 	 * We're only interested in posts that are transitioning into publish.
 	 */
 	if ( 'publish' !== $new_status || 'publish' === $old_status ) {
 		return;
 	}
 
-	/**
+	/*
 	 * Don't bother enqueuing assets if the post type hasn't opted into autosharing
 	 */
 	if ( ! Utils\opted_into_autoshare_for_twitter( $post->ID ) ) {
 		return;
 	}
 
-	/**
-	 * Don't publish tweets from staging/testing sites.
-	 */
+	// Don't publish tweets from staging/testing sites.
 	if ( ! AST_Staging::is_production_site() ) {
 		return;
 	}
@@ -94,16 +92,14 @@ function maybe_publish_tweet( $new_status, $old_status, $post ) {
 function publish_tweet( $post_id ) {
 	$post = get_post( $post_id );
 
-	/**
+	/*
 	 * Don't bother enqueuing assets if the post type hasn't opted into autosharing
 	 */
 	if ( ! Utils\opted_into_autoshare_for_twitter( $post->ID ) ) {
 		return;
 	}
 
-	/**
-	 * Don't publish tweets from staging/testing sites.
-	 */
+	// Don't publish tweets from staging/testing sites.
 	if ( ! AST_Staging::is_production_site() ) {
 		return;
 	}
@@ -113,7 +109,7 @@ function publish_tweet( $post_id ) {
 		return;
 	}
 
-	/**
+	/*
 	 * One final check: was the "auto tweet" checkbox selected?
 	 */
 	if ( Utils\autoshare_enabled( $post->ID ) ) {

--- a/includes/admin/post-transition.php
+++ b/includes/admin/post-transition.php
@@ -8,6 +8,7 @@
 namespace TenUp\AutoshareForTwitter\Core\Post_Transition;
 
 use TenUp\AutoshareForTwitter\Core\Publish_Tweet\Publish_Tweet;
+use TenUp\AutoshareForTwitter\Core\AST_Staging\AST_Staging;
 use TenUp\AutoshareForTwitter\Core\Post_Meta as Meta;
 use TenUp\AutoshareForTwitter\Utils as Utils;
 use function TenUp\AutoshareForTwitter\Utils\delete_autoshare_for_twitter_meta;
@@ -61,6 +62,13 @@ function maybe_publish_tweet( $new_status, $old_status, $post ) {
 		return;
 	}
 
+	/**
+	 * Don't publish tweets from staging/testing sites.
+	 */
+	if ( AST_Staging::is_duplicate_site() ) {
+		return;
+	}
+
 	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
 		add_action(
 			sprintf( 'rest_after_insert_%s', $post->post_type ),
@@ -90,6 +98,13 @@ function publish_tweet( $post_id ) {
 	 * Don't bother enqueuing assets if the post type hasn't opted into autosharing
 	 */
 	if ( ! Utils\opted_into_autoshare_for_twitter( $post->ID ) ) {
+		return;
+	}
+
+	/**
+	 * Don't publish tweets from staging/testing sites.
+	 */
+	if ( AST_Staging::is_duplicate_site() ) {
 		return;
 	}
 

--- a/includes/class-ast-staging.php
+++ b/includes/class-ast-staging.php
@@ -204,8 +204,6 @@ class AST_Staging {
 	public static function get_site_url_from_source( $source = 'current_wp_site' ) {
 		if ( 'autoshare' === $source ) {
 			$site_url = self::get_authoshare_live_site_url();
-		} elseif ( ! is_multisite() && defined( 'WP_SITEURL' ) ) {
-			$site_url = WP_SITEURL;
 		} else {
 			$site_url = get_site_url();
 		}

--- a/includes/class-ast-staging.php
+++ b/includes/class-ast-staging.php
@@ -72,7 +72,7 @@ class AST_Staging {
 						'</strong>',
 						'<a href="' . esc_url( self::get_site_url_from_source( 'autoshare' ) ) . '" target="_blank">',
 						'</a>',
-						esc_url( self::get_site_url_from_source( 'autoshare' ) ),
+						esc_url( self::get_site_url_from_source( 'autoshare' ) )
 					)
 					?>
 				</p>
@@ -168,7 +168,7 @@ class AST_Staging {
 	 */
 	public static function get_autoshare_site_url_lock_key() {
 		$site_url = self::get_site_url_from_source( 'current_wp_site' );
-		$scheme   = parse_url( $site_url, PHP_URL_SCHEME ) . '://';
+		$scheme   = wp_parse_url( $site_url, PHP_URL_SCHEME ) . '://';
 		$site_url = str_replace( $scheme, '', $site_url );
 
 		return $scheme . substr_replace( $site_url, '_[autoshare_siteurl]_', strlen( $site_url ) / 2, 0 );

--- a/includes/class-ast-staging.php
+++ b/includes/class-ast-staging.php
@@ -11,6 +11,7 @@ namespace TenUp\AutoshareForTwitter\Core\AST_Staging;
  * Autoshare For Twitter staging mode handler.
  *
  * @package TenUp\AutoshareForTwitter\Core
+ *
  * @since   1.2.0
  */
 class AST_Staging {
@@ -95,6 +96,7 @@ class AST_Staging {
 	 * Checks if the current WordPress URL is the same as the URL Autoshare considers the live URL.
 	 *
 	 * @since 1.2.0
+	 *
 	 * @return bool Whether the site is a production URL or not.
 	 */
 	public static function is_production_site() {
@@ -126,6 +128,7 @@ class AST_Staging {
 		 * Filters value of "Is production site?".
 		 *
 		 * @since 1.2.0
+		 *
 		 * @param boolean $is_production Whether the site is a production URL or not.
 		 */
 		return apply_filters( 'autoshare_for_twitter_is_production_site', $is_production );
@@ -144,6 +147,7 @@ class AST_Staging {
 			self::set_autoshare_live_url_lock();
 		}
 	}
+
 	/**
 	 * Sets the autoshare site lock key to record the site's "live" url.
 	 *
@@ -155,7 +159,6 @@ class AST_Staging {
 		update_option( 'autoshare_liveurl', self::get_autoshare_live_url_lock_key() );
 	}
 
-
 	/**
 	 * Generates a unique key based on the sites URL used to determine duplicate/staging sites.
 	 *
@@ -164,6 +167,7 @@ class AST_Staging {
 	 * the URL by inserting '_[autoshare_liveurl]_' into the middle of it.
 	 *
 	 * @since 1.2.0
+	 *
 	 * @return string The autoshare live URL lock key.
 	 */
 	public static function get_autoshare_live_url_lock_key() {

--- a/includes/class-ast-staging.php
+++ b/includes/class-ast-staging.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Class to handle staging site Autoshare.
+ *
+ * @package TenUp\AutoshareForTwitter\Core
+ */
+
+namespace TenUp\AutoshareForTwitter\Core\AST_Staging;
+
+/**
+ * Autoshare For Twitter staging mode handler.
+ *
+ * @package TenUp\AutoshareForTwitter\Core
+ * @since   1.2.0
+ */
+class AST_Staging {
+
+	/**
+	 * Add actions
+	 */
+	public static function init() {
+		add_action( 'init', array( __CLASS__, 'maybe_add_autoshare_site_url' ) );
+		add_action( 'admin_init', array( __CLASS__, 'handle_site_change_notice_actions' ) );
+		add_action( 'admin_notices', array( __CLASS__, 'handle_site_change_notice' ) );
+	}
+
+	/**
+	 * Handle site change notice actions
+	 *
+	 * @since 1.2.0
+	 */
+	public static function handle_site_change_notice_actions() {
+		if ( self::is_duplicate_site() && current_user_can( 'manage_options' ) ) {
+
+			if (
+				! empty( $_GET['_astnonce'] ) &&
+				wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_astnonce'] ) ), 'ast_duplicate_site' ) &&
+				isset( $_GET['autoshare_duplicate_site'] )
+			) {
+				$duplicate_site = sanitize_text_field( wp_unslash( $_GET['autoshare_duplicate_site'] ) );
+				if ( 'update' === $duplicate_site ) {
+					self::set_autoshare_site_url_lock();
+				} elseif ( 'ignore' === $duplicate_site ) {
+					update_option( 'autoshare_ignore_duplicate_siteurl_notice', self::get_autoshare_site_url_lock_key() );
+				}
+				wp_safe_redirect( remove_query_arg( array( 'autoshare_duplicate_site', '_astnonce' ) ) );
+			}
+		}
+	}
+
+	/**
+	 * Displays a notice when plugin is being run on a different site, like a staging or testing site.
+	 *
+	 * @since 1.2.0
+	 */
+	public static function handle_site_change_notice() {
+		if (
+			self::is_duplicate_site() &&
+			current_user_can( 'manage_options' ) &&
+			self::get_autoshare_site_url_lock_key() !== get_option( 'autoshare_ignore_duplicate_siteurl_notice' )
+		) {
+			$ignore_url = wp_nonce_url( add_query_arg( 'autoshare_duplicate_site', 'ignore' ), 'ast_duplicate_site', '_astnonce' );
+			$update_url = wp_nonce_url( add_query_arg( 'autoshare_duplicate_site', 'update' ), 'ast_duplicate_site', '_astnonce' );
+			?>
+			<div class="notice notice-error">
+				<p>
+					<?php
+					printf(
+						// translators: 1$-2$: opening and closing <strong> tags. 3$-4$: Opening and closing link to production URL. 5$: Production URL.
+						esc_html__( 'It looks like this site has moved or is a duplicate site. %1$sAutoshare for Twitter%2$s has disabled publish tweets on this site to prevent tweets from a staging or test environment. %1$sAutoshare for Twitter%2$s considers %3$s%5$s%4$s to be the site\'s URL. ', 'autoshare-for-twitter' ),
+						'<strong>',
+						'</strong>',
+						'<a href="' . esc_url( self::get_site_url_from_source( 'autoshare' ) ) . '" target="_blank">',
+						'</a>',
+						esc_url( self::get_site_url_from_source( 'autoshare' ) ),
+					)
+					?>
+				</p>
+				<p>
+					<a class="button button-primary" href="<?php echo esc_url( $ignore_url ); ?>">
+						<?php esc_html_e( 'Dismiss this (but don\'t enable publish tweets)', 'autoshare-for-twitter' ); ?>
+					</a>
+					<a class="button" href="<?php echo esc_url( $update_url ); ?>">
+						<?php esc_html_e( 'Enable publish tweets', 'autoshare-for-twitter' ); ?>
+					</a>
+				</p>
+			</div>
+			<?php
+		}
+	}
+
+	/**
+	 * Determines if this is a testing/staging site.
+	 *
+	 * Checks if the WordPress site URL is the same as the URL Autoshare considers the live URL.
+	 *
+	 * @since 1.2.0
+	 * @return bool Whether the site is a staging URL or not.
+	 */
+	public static function is_duplicate_site() {
+		$wp_site_url_parts  = wp_parse_url( self::get_site_url_from_source( 'current_wp_site' ) );
+		$ast_site_url_parts = wp_parse_url( self::get_site_url_from_source( 'autoshare' ) );
+
+		if ( ! isset( $wp_site_url_parts['path'] ) && ! isset( $ast_site_url_parts['path'] ) ) {
+			$paths_match = true;
+		} elseif ( isset( $wp_site_url_parts['path'] ) && isset( $ast_site_url_parts['path'] ) && $wp_site_url_parts['path'] === $ast_site_url_parts['path'] ) {
+			$paths_match = true;
+		} else {
+			$paths_match = false;
+		}
+
+		if ( isset( $wp_site_url_parts['host'] ) && isset( $ast_site_url_parts['host'] ) && $wp_site_url_parts['host'] === $ast_site_url_parts['host'] ) {
+			$hosts_match = true;
+		} else {
+			$hosts_match = false;
+		}
+
+		// Check the host and path, do not check the protocol/scheme to avoid issues.
+		if ( $paths_match && $hosts_match ) {
+			$is_duplicate = false;
+		} else {
+			$is_duplicate = true;
+		}
+
+		/**
+		 * Filters value of "Is staging site?".
+		 *
+		 * @since 1.2.0
+		 * @param boolean $is_duplicate Is staging site?.
+		 */
+		return apply_filters( 'autoshare_for_twitter_is_duplicate_site', $is_duplicate );
+	}
+
+	/**
+	 * Save autoshare live site URL in database if it is not saved.
+	 *
+	 * @since 1.2.0
+	 */
+	public static function maybe_add_autoshare_site_url() {
+		$autoshare_site_url = get_option( 'autoshare_siteurl', false );
+
+		// Check if autoshare site url is stored in options, save option if not stored.
+		if ( false === $autoshare_site_url ) {
+			self::set_autoshare_site_url_lock();
+		}
+	}
+	/**
+	 * Sets the autoshare site lock key to record the site's "live" url.
+	 *
+	 * This key is checked to determine if this database has moved to a different URL.
+	 *
+	 * @since 1.2.0
+	 */
+	public static function set_autoshare_site_url_lock() {
+		update_option( 'autoshare_siteurl', self::get_autoshare_site_url_lock_key() );
+	}
+
+
+	/**
+	 * Generates a unique key based on the sites URL used to determine duplicate/staging sites.
+	 *
+	 * The key can not simply be the site URL, e.g. http://example.com, because some hosts replaces all
+	 * instances of the site URL in the database when creating a staging site. As a result, we obfuscate
+	 * the URL by inserting '_[autoshare_siteurl]_' into the middle of it.
+	 *
+	 * @since 1.2.0
+	 * @return string The autoshare site URL lock key.
+	 */
+	public static function get_autoshare_site_url_lock_key() {
+		$site_url = self::get_site_url_from_source( 'current_wp_site' );
+		$scheme   = parse_url( $site_url, PHP_URL_SCHEME ) . '://';
+		$site_url = str_replace( $scheme, '', $site_url );
+
+		return $scheme . substr_replace( $site_url, '_[autoshare_siteurl]_', strlen( $site_url ) / 2, 0 );
+	}
+
+	/**
+	 * Gets the URL Autoshare considers as the live site URL.
+	 *
+	 * This URL is set by `self::set_autoshare_site_url_lock()`. This function removes the obfuscation to get a raw URL.
+	 *
+	 * @since 1.2.0
+	 */
+	public static function get_authoshare_live_site_url() {
+		$url = get_option( 'autoshare_siteurl', '' );
+
+		// Remove the prefix used to prevent the site URL being updated by search & replace.
+		$url = str_replace( '_[autoshare_siteurl]_', '', $url );
+
+		return $url;
+	}
+
+	/**
+	 * Gets the sites WordPress or Autoshare URL.
+	 *
+	 * WordPress - This is typically the URL the current site is accessible via.
+	 * Autoshare URL is the URL Autoshare considers to be the URL to publish/autoshare tweet on. It may differ to the WP URL if the site has moved.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param string $source The URL source to get. Optional. Takes values 'current_wp_site' or 'autoshare'. Default is 'current_wp_site'.
+	 * @return string The URL.
+	 */
+	public static function get_site_url_from_source( $source = 'current_wp_site' ) {
+		if ( 'autoshare' === $source ) {
+			$site_url = self::get_authoshare_live_site_url();
+		} elseif ( ! is_multisite() && defined( 'WP_SITEURL' ) ) {
+			$site_url = WP_SITEURL;
+		} else {
+			$site_url = get_site_url();
+		}
+
+		return $site_url;
+	}
+}

--- a/includes/class-ast-staging.php
+++ b/includes/class-ast-staging.php
@@ -92,7 +92,7 @@ class AST_Staging {
 	/**
 	 * Determines if this is a production site.
 	 *
-	 * Checks if the WordPress site URL is the same as the URL Autoshare considers the live URL.
+	 * Checks if the current WordPress URL is the same as the URL Autoshare considers the live URL.
 	 *
 	 * @since 1.2.0
 	 * @return bool Whether the site is a production URL or not.
@@ -164,7 +164,7 @@ class AST_Staging {
 	 * the URL by inserting '_[autoshare_liveurl]_' into the middle of it.
 	 *
 	 * @since 1.2.0
-	 * @return string The autoshare site URL lock key.
+	 * @return string The autoshare live URL lock key.
 	 */
 	public static function get_autoshare_live_url_lock_key() {
 		$url    = self::get_url_from_source( 'current_wp_site' );
@@ -175,7 +175,7 @@ class AST_Staging {
 	}
 
 	/**
-	 * Gets the URL Autoshare considers as the live site URL.
+	 * Gets the URL Autoshare considers as the live URL.
 	 *
 	 * This URL is set by `self::set_autoshare_live_url_lock()`. This function removes the obfuscation to get a raw URL.
 	 *

--- a/includes/core.php
+++ b/includes/core.php
@@ -8,6 +8,7 @@
 namespace TenUp\AutoshareForTwitter\Core;
 
 use TenUp\AutoshareForTwitter\Utils;
+use TenUp\AutoshareForTwitter\Core\AST_Staging\AST_Staging;
 use const TenUp\AutoshareForTwitter\Core\Post_Meta\TWITTER_STATUS_KEY;
 use function TenUp\AutoshareForTwitter\Utils\autoshare_enabled;
 
@@ -21,11 +22,15 @@ function setup() {
 	require_once plugin_dir_path( AUTOSHARE_FOR_TWITTER ) . 'includes/admin/settings.php';
 	require_once plugin_dir_path( AUTOSHARE_FOR_TWITTER ) . 'includes/admin/post-meta.php';
 	require_once plugin_dir_path( AUTOSHARE_FOR_TWITTER ) . 'includes/admin/post-transition.php';
+	require_once plugin_dir_path( AUTOSHARE_FOR_TWITTER ) . 'includes/class-ast-staging.php';
 	require_once plugin_dir_path( AUTOSHARE_FOR_TWITTER ) . 'includes/class-publish-tweet.php';
 	require_once plugin_dir_path( AUTOSHARE_FOR_TWITTER ) . 'includes/rest.php';
 
 	\TenUp\AutoshareForTwitter\Admin\Assets\add_hook_callbacks();
 	\TenUp\AutoshareForTwitter\REST\add_hook_callbacks();
+
+	// Initiate staging class.
+	AST_Staging::init();
 
 	/**
 	 * Allow others to hook into the core setup action


### PR DESCRIPTION
### Description of the Change
This PR adds support for detecting staging/testing environments and handling publish tweets from staging/testing/local environments to prevent publishing accidental tweets.

The plugin saves a live site URL to the options table with `_[autoshare_siteurl]_` in the middle of it, to prevent it from getting replaced by a search-replace script during migraion. So, whenever the current wp site URL doesn't match with the saved live site URL, the plugin shows the notice to the admin user and stops publishing tweets. Admin users can enable publish tweets OR dismiss notice with keep publish tweet disabled.

![image](https://user-images.githubusercontent.com/10613171/168273947-ed4b94cd-6acc-4efc-ac31-4451633acd0c.png)

Closes #39 

### Alternate Designs
Maybe we can move the credentials store from sb to wp-config.php, to prevent accidental tweets.

### Possible Drawbacks
Didn't notice any yet.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
1. Create a website/blog with WP and setup AST on it
2. Migrate the website to a different domain.
3. You will see the notice related to the staging/testing site and publish tweets will be disabled.
4. Test notice actions and make sure it works as expected.
<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->
Added - Handle publish tweets from staging/testing/local environments to prevent publishing accidental tweets.

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @iamdharmesh @dinhtungdu 
