### PR TITLE
Added `autoloader-suffix` in composer config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ The `develop` branch is the development branch which means it contains the next 
 ## Release instructions
 
 1. Branch: Starting from `develop`, cut a release branch named `release/X.Y.Z` for your changes.
-1. Version bump: Bump the version number in `autoshare-for-twitter.php`, `readme.txt`, `package-lock.json`, and `package.json` if it does not already reflect the version being released.
+1. Version bump: Bump the version number in `autoshare-for-twitter.php`, `readme.txt`, `package-lock.json`, `package.json`, and `composer.json`(`autoloader-suffix` config option) if it does not already reflect the version being released.
 1. Changelog: Add/update the changelog in `CHANGELOG.md` and `readme.txt`.
 1. Props: update `CREDITS.md` with any new contributors, confirm maintainers are accurate.
 1. New files: Check to be sure any new files/paths that are unnecessary in the production version are included in `.distignore`.

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
 	},
 	"minimum-stability": "dev",
 	"config": {
+		"autoloader-suffix": "10upAutoshareForTwitterV111",
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
 		}


### PR DESCRIPTION
### Description of the Change
As described in #164, "Plugin asset/readme update" GH action is failing to deploy readme.txt because of autoload files of the composer. Composer generates new autoload files during composer install in GH action, which are different from the files commited in the svn repo of wp.org. 

This PR adds `autoloader-suffix` in the composer config to generate the same autoload files with every install. So, the readme.txt file can deploy on minor changes or wp tested up to bumps. 

Value of `autoloader-suffix` is in this format **10up{PLUGIN_NAME}{PLUGIN_VERSION}** => `10upAutoshareForTwitterV111`

Closes #164 

### Alternate Designs
We may use the `IGNORE_OTHER_FILES` option of GH action, but I feel `autoloader-suffix` is a better approach here, because with  `IGNORE_OTHER_FILES` readme.txt file will be deployed with every change in it. (Think of readme update for plugin version bump merged in the trunk but we didn't added tag yet for release to deploy it on wp.org)

### Possible Drawbacks
Not any

### Verification Process
This can be verified with the successful deployment of readme.txt after the next release.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->
Fixed - "Plugin asset/readme update" GH action failure.

### Credits

Props @iamdharmesh 
