### PR TITLE
Run E2E tests with `Enable by default` option checked and unchecked.

### DIFF
--- a/tests/cypress/integration/block-editor.test.js
+++ b/tests/cypress/integration/block-editor.test.js
@@ -1,9 +1,9 @@
 describe('Test Autoshare for Twitter with Block Editor.', () => {
-	before(()=>{
+	before(() => {
 		cy.login();
 		// Ignore WP 5.2 Synchronous XHR error.
 		Cypress.on('uncaught:exception', (err, runnable) => {
-			if (err.message.includes("Failed to execute 'send' on 'XMLHttpRequest': Failed to load 'http://localhost:8889/wp-admin/admin-ajax.php': Synchronous XHR in page dismissal") ){
+			if (err.message.includes("Failed to execute 'send' on 'XMLHttpRequest': Failed to load 'http://localhost:8889/wp-admin/admin-ajax.php': Synchronous XHR in page dismissal") ) {
 				return false;
 			}
 		});
@@ -17,112 +17,127 @@ describe('Test Autoshare for Twitter with Block Editor.', () => {
 	});
 
 	// Run test cases with default Autoshare enabled and disabled both.
-	const defaultBehaviors = [true, false];
-	defaultBehaviors.forEach( (defaultBehavior) => {	
-		it(`Can ${(defaultBehavior ? 'Enable': 'Disable')} default Autoshare`, () => {
+	const defaultBehaviors = [false, true];
+	defaultBehaviors.forEach((defaultBehavior) => {
+		it(`Can ${defaultBehavior ? 'Enable' : 'Disable'} default Autoshare`, () => {
 			cy.visit('/wp-admin/options-general.php?page=autoshare-for-twitter');
-			cy.get('input:checkbox[name="autoshare-for-twitter[enable_default]"]').should('exist');
+
+			const defaultSelector = 'input:checkbox[name="autoshare-for-twitter[enable_default]"]';
+			cy.get(defaultSelector).should('exist');
 			if (true === defaultBehavior) {
-				cy.get('input:checkbox[name="autoshare-for-twitter[enable_default]"]').uncheck();
+				cy.get(defaultSelector).check();
 			} else {
-				cy.get('input:checkbox[name="autoshare-for-twitter[enable_default]"]').uncheck();
+				cy.get(defaultSelector).uncheck();
 			}
 			cy.get('#submit').click();
 		});
-	
+
 		it('Tests that new post is not tweeted when box is unchecked', () => {
 			// Start create new post by enter post title
 			cy.startCreatePost();
-			
+
+			// Open pre-publish Panel.
 			cy.get('.editor-post-publish-panel__toggle').should('be.visible');
 			cy.get('.editor-post-publish-panel__toggle').click();
-	
+
+			// Check enable checkbox for auto-share.
+			cy.get('.components-panel__body:contains("Autoshare:")').should('exist');
+			cy.get('.components-panel__body:contains("Autoshare:")').click();
+
+			const checkboxSelector =
+				'.autoshare-for-twitter-prepublish__checkbox input:checkbox';
+			cy.get(checkboxSelector).should('be.visible');
+			if (true === defaultBehavior) {
+				cy.get(checkboxSelector).should('be.checked');
+				cy.get(checkboxSelector).uncheck();
+				cy.get(checkboxSelector).should('not.be.checked');
+			} else {
+				cy.get(checkboxSelector).should('not.be.checked');
+			}
+
 			// Publish
 			cy.get('.editor-post-publish-button').should('be.visible');
 			cy.get('.editor-post-publish-button').click();
-	
+
 			// Post-publish.
 			cy.get('.autoshare-for-twitter-post-status').should('be.visible');
 			cy.get('.autoshare-for-twitter-post-status').contains('This post was not tweeted.');
 		});
-	
-	
-		it('Tests that new post is tweeted when box is checked', () => {
+
+		it.skip('Tests that new post is tweeted when box is checked', () => {
 			// Start create new post by enter post title
 			cy.startCreatePost();
-	
+
 			// Open pre-publish Panel.
 			cy.get('.editor-post-publish-panel__toggle').should('be.visible');
 			cy.get('.editor-post-publish-panel__toggle').click();
 			cy.get('.components-panel__body:contains("Autoshare:")').should('exist');
 			cy.get('.components-panel__body:contains("Autoshare:")').click();
-	
+
 			// Check enable checkbox for auto-share.
 			cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').should('be.visible');
 			cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').check();
-	
+
 			// Publish.
 			cy.get('[aria-disabled="false"].editor-post-publish-button').should('be.visible');
 			cy.get('.editor-post-publish-button').click();
-	
+
 			// Post-publish.
 			cy.get('.autoshare-for-twitter-post-status').should('be.visible');
 			cy.get('.autoshare-for-twitter-post-status').contains('Tweeted on');
 		});
-	
-	
-		it('Tests that Draft post is not tweeted when box is unchecked', () => {
+
+		it.skip('Tests that Draft post is not tweeted when box is unchecked', () => {
 			// Start create new post by enter post title
 			cy.startCreatePost();
-	
+
 			// Save Draft
 			cy.get('.editor-post-save-draft').should('be.visible');
 			cy.get('.editor-post-save-draft').click();
 			cy.get('.editor-post-saved-state').should('have.text', 'Saved');
-	
+
 			// Open pre-publish Panel.
 			cy.get('.editor-post-publish-panel__toggle').should('be.visible');
 			cy.get('.editor-post-publish-panel__toggle').click();
 			cy.get('.components-panel__body:contains("Autoshare:")').should('exist');
 			cy.get('.components-panel__body:contains("Autoshare:")').click();
-	
+
 			// Uncheck enable checkbox for auto-share.
 			cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').should('be.visible');
 			cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').uncheck();
-	
+
 			// Publish.
 			cy.get('[aria-disabled="false"].editor-post-publish-button').should('be.visible');
 			cy.get('.editor-post-publish-button').click();
-	
+
 			// Post-publish.
 			cy.get('.autoshare-for-twitter-post-status').should('be.visible');
 			cy.get('.autoshare-for-twitter-post-status').contains('This post was not tweeted.');
 		});
-	
-		
-		it('Tests that Draft post is tweeted when box is checked', () => {
+
+		it.skip('Tests that Draft post is tweeted when box is checked', () => {
 			// Start create new post by enter post title
 			cy.startCreatePost();
-	
+
 			// Save Draft
 			cy.get('.editor-post-save-draft').should('be.visible');
 			cy.get('.editor-post-save-draft').click();
 			cy.get('.editor-post-saved-state').should('have.text', 'Saved');
-			
+
 			// Open pre-publish Panel.
 			cy.get('.editor-post-publish-panel__toggle').should('be.visible');
 			cy.get('.editor-post-publish-panel__toggle').click();
 			cy.get('.components-panel__body:contains("Autoshare:")').should('exist');
 			cy.get('.components-panel__body:contains("Autoshare:")').click();
-	
+
 			// Check enable checkbox for auto-share.
 			cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').should('be.visible');
 			cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').check();
-	
+
 			// Publish.
 			cy.get('[aria-disabled="false"].editor-post-publish-button').should('be.visible');
 			cy.get('.editor-post-publish-button').click();
-	
+
 			// Post-publish.
 			cy.get('.autoshare-for-twitter-post-status').should('be.visible');
 			cy.get('.autoshare-for-twitter-post-status').contains('Tweeted on');

--- a/tests/cypress/integration/block-editor.test.js
+++ b/tests/cypress/integration/block-editor.test.js
@@ -16,110 +16,116 @@ describe('Test Autoshare for Twitter with Block Editor.', () => {
 		cy.get('#submit').click();
 	});
 
-
-	it('Can disable default Autoshare', () => {
-		cy.visit('/wp-admin/options-general.php?page=autoshare-for-twitter');
-		cy.get('input:checkbox[name="autoshare-for-twitter[enable_default]"]').should('exist');
-		cy.get('input:checkbox[name="autoshare-for-twitter[enable_default]"]').uncheck();
-		cy.get('#submit').click();
-	});
-
-
-	it('Tests that new post is not tweeted when box is unchecked', () => {
-		// Start create new post by enter post title
-		cy.startCreatePost();
-		
-		cy.get('.editor-post-publish-panel__toggle').should('be.visible');
-		cy.get('.editor-post-publish-panel__toggle').click();
-
-		// Publish
-		cy.get('.editor-post-publish-button').should('be.visible');
-		cy.get('.editor-post-publish-button').click();
-
-		// Post-publish.
-		cy.get('.autoshare-for-twitter-post-status').should('be.visible');
-		cy.get('.autoshare-for-twitter-post-status').contains('This post was not tweeted.');
-	});
-
-
-	it('Tests that new post is tweeted when box is checked', () => {
-		// Start create new post by enter post title
-		cy.startCreatePost();
-
-		// Open pre-publish Panel.
-		cy.get('.editor-post-publish-panel__toggle').should('be.visible');
-		cy.get('.editor-post-publish-panel__toggle').click();
-		cy.get('.components-panel__body:contains("Autoshare:")').should('exist');
-		cy.get('.components-panel__body:contains("Autoshare:")').click();
-
-		// Check enable checkbox for auto-share.
-		cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').should('be.visible');
-		cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').check();
-
-		// Publish.
-		cy.get('[aria-disabled="false"].editor-post-publish-button').should('be.visible');
-		cy.get('.editor-post-publish-button').click();
-
-		// Post-publish.
-		cy.get('.autoshare-for-twitter-post-status').should('be.visible');
-		cy.get('.autoshare-for-twitter-post-status').contains('Tweeted on');
-	});
-
-
-	it('Tests that Draft post is not tweeted when box is unchecked', () => {
-		// Start create new post by enter post title
-		cy.startCreatePost();
-
-		// Save Draft
-		cy.get('.editor-post-save-draft').should('be.visible');
-		cy.get('.editor-post-save-draft').click();
-		cy.get('.editor-post-saved-state').should('have.text', 'Saved');
-
-		// Open pre-publish Panel.
-		cy.get('.editor-post-publish-panel__toggle').should('be.visible');
-		cy.get('.editor-post-publish-panel__toggle').click();
-		cy.get('.components-panel__body:contains("Autoshare:")').should('exist');
-		cy.get('.components-panel__body:contains("Autoshare:")').click();
-
-		// Uncheck enable checkbox for auto-share.
-		cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').should('be.visible');
-		cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').uncheck();
-
-		// Publish.
-		cy.get('[aria-disabled="false"].editor-post-publish-button').should('be.visible');
-		cy.get('.editor-post-publish-button').click();
-
-		// Post-publish.
-		cy.get('.autoshare-for-twitter-post-status').should('be.visible');
-		cy.get('.autoshare-for-twitter-post-status').contains('This post was not tweeted.');
-	});
-
+	// Run test cases with default Autoshare enabled and disabled both.
+	const defaultBehaviors = [true, false];
+	defaultBehaviors.forEach( (defaultBehavior) => {	
+		it(`Can ${(defaultBehavior ? 'Enable': 'Disable')} default Autoshare`, () => {
+			cy.visit('/wp-admin/options-general.php?page=autoshare-for-twitter');
+			cy.get('input:checkbox[name="autoshare-for-twitter[enable_default]"]').should('exist');
+			if (true === defaultBehavior) {
+				cy.get('input:checkbox[name="autoshare-for-twitter[enable_default]"]').uncheck();
+			} else {
+				cy.get('input:checkbox[name="autoshare-for-twitter[enable_default]"]').uncheck();
+			}
+			cy.get('#submit').click();
+		});
 	
-	it('Tests that Draft post is tweeted when box is checked', () => {
-		// Start create new post by enter post title
-		cy.startCreatePost();
-
-		// Save Draft
-		cy.get('.editor-post-save-draft').should('be.visible');
-		cy.get('.editor-post-save-draft').click();
-		cy.get('.editor-post-saved-state').should('have.text', 'Saved');
+		it('Tests that new post is not tweeted when box is unchecked', () => {
+			// Start create new post by enter post title
+			cy.startCreatePost();
+			
+			cy.get('.editor-post-publish-panel__toggle').should('be.visible');
+			cy.get('.editor-post-publish-panel__toggle').click();
+	
+			// Publish
+			cy.get('.editor-post-publish-button').should('be.visible');
+			cy.get('.editor-post-publish-button').click();
+	
+			// Post-publish.
+			cy.get('.autoshare-for-twitter-post-status').should('be.visible');
+			cy.get('.autoshare-for-twitter-post-status').contains('This post was not tweeted.');
+		});
+	
+	
+		it('Tests that new post is tweeted when box is checked', () => {
+			// Start create new post by enter post title
+			cy.startCreatePost();
+	
+			// Open pre-publish Panel.
+			cy.get('.editor-post-publish-panel__toggle').should('be.visible');
+			cy.get('.editor-post-publish-panel__toggle').click();
+			cy.get('.components-panel__body:contains("Autoshare:")').should('exist');
+			cy.get('.components-panel__body:contains("Autoshare:")').click();
+	
+			// Check enable checkbox for auto-share.
+			cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').should('be.visible');
+			cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').check();
+	
+			// Publish.
+			cy.get('[aria-disabled="false"].editor-post-publish-button').should('be.visible');
+			cy.get('.editor-post-publish-button').click();
+	
+			// Post-publish.
+			cy.get('.autoshare-for-twitter-post-status').should('be.visible');
+			cy.get('.autoshare-for-twitter-post-status').contains('Tweeted on');
+		});
+	
+	
+		it('Tests that Draft post is not tweeted when box is unchecked', () => {
+			// Start create new post by enter post title
+			cy.startCreatePost();
+	
+			// Save Draft
+			cy.get('.editor-post-save-draft').should('be.visible');
+			cy.get('.editor-post-save-draft').click();
+			cy.get('.editor-post-saved-state').should('have.text', 'Saved');
+	
+			// Open pre-publish Panel.
+			cy.get('.editor-post-publish-panel__toggle').should('be.visible');
+			cy.get('.editor-post-publish-panel__toggle').click();
+			cy.get('.components-panel__body:contains("Autoshare:")').should('exist');
+			cy.get('.components-panel__body:contains("Autoshare:")').click();
+	
+			// Uncheck enable checkbox for auto-share.
+			cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').should('be.visible');
+			cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').uncheck();
+	
+			// Publish.
+			cy.get('[aria-disabled="false"].editor-post-publish-button').should('be.visible');
+			cy.get('.editor-post-publish-button').click();
+	
+			// Post-publish.
+			cy.get('.autoshare-for-twitter-post-status').should('be.visible');
+			cy.get('.autoshare-for-twitter-post-status').contains('This post was not tweeted.');
+		});
+	
 		
-		// Open pre-publish Panel.
-		cy.get('.editor-post-publish-panel__toggle').should('be.visible');
-		cy.get('.editor-post-publish-panel__toggle').click();
-		cy.get('.components-panel__body:contains("Autoshare:")').should('exist');
-		cy.get('.components-panel__body:contains("Autoshare:")').click();
-
-		// Check enable checkbox for auto-share.
-		cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').should('be.visible');
-		cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').check();
-
-		// Publish.
-		cy.get('[aria-disabled="false"].editor-post-publish-button').should('be.visible');
-		cy.get('.editor-post-publish-button').click();
-
-		// Post-publish.
-		cy.get('.autoshare-for-twitter-post-status').should('be.visible');
-		cy.get('.autoshare-for-twitter-post-status').contains('Tweeted on');
+		it('Tests that Draft post is tweeted when box is checked', () => {
+			// Start create new post by enter post title
+			cy.startCreatePost();
+	
+			// Save Draft
+			cy.get('.editor-post-save-draft').should('be.visible');
+			cy.get('.editor-post-save-draft').click();
+			cy.get('.editor-post-saved-state').should('have.text', 'Saved');
+			
+			// Open pre-publish Panel.
+			cy.get('.editor-post-publish-panel__toggle').should('be.visible');
+			cy.get('.editor-post-publish-panel__toggle').click();
+			cy.get('.components-panel__body:contains("Autoshare:")').should('exist');
+			cy.get('.components-panel__body:contains("Autoshare:")').click();
+	
+			// Check enable checkbox for auto-share.
+			cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').should('be.visible');
+			cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').check();
+	
+			// Publish.
+			cy.get('[aria-disabled="false"].editor-post-publish-button').should('be.visible');
+			cy.get('.editor-post-publish-button').click();
+	
+			// Post-publish.
+			cy.get('.autoshare-for-twitter-post-status').should('be.visible');
+			cy.get('.autoshare-for-twitter-post-status').contains('Tweeted on');
+		});
 	});
 });

--- a/tests/cypress/integration/block-editor.test.js
+++ b/tests/cypress/integration/block-editor.test.js
@@ -37,26 +37,13 @@ describe('Test Autoshare for Twitter with Block Editor.', () => {
 			cy.startCreatePost();
 
 			// Open pre-publish Panel.
-			cy.get('.editor-post-publish-panel__toggle').should('be.visible');
-			cy.get('.editor-post-publish-panel__toggle').click();
-
+			cy.openPrePublishPanel();
+			
 			// Check enable checkbox for auto-share.
-			cy.get('.components-panel__body:contains("Autoshare:")').should('exist');
-			cy.get('.components-panel__body:contains("Autoshare:")').click();
-
-			const checkboxSelector =
-				'.autoshare-for-twitter-prepublish__checkbox input:checkbox';
-			cy.get(checkboxSelector).should('be.visible');
-			if (true === defaultBehavior) {
-				cy.get(checkboxSelector).should('be.checked');
-				cy.get(checkboxSelector).uncheck();
-				cy.get(checkboxSelector).should('not.be.checked');
-			} else {
-				cy.get(checkboxSelector).should('not.be.checked');
-			}
+			cy.enableCheckbox('.autoshare-for-twitter-prepublish__checkbox input:checkbox', defaultBehavior, false);
 
 			// Publish
-			cy.get('.editor-post-publish-button').should('be.visible');
+			cy.get('[aria-disabled="false"].editor-post-publish-button').should('be.visible');
 			cy.get('.editor-post-publish-button').click();
 
 			// Post-publish.
@@ -64,19 +51,15 @@ describe('Test Autoshare for Twitter with Block Editor.', () => {
 			cy.get('.autoshare-for-twitter-post-status').contains('This post was not tweeted.');
 		});
 
-		it.skip('Tests that new post is tweeted when box is checked', () => {
+		it('Tests that new post is tweeted when box is checked', () => {
 			// Start create new post by enter post title
 			cy.startCreatePost();
 
 			// Open pre-publish Panel.
-			cy.get('.editor-post-publish-panel__toggle').should('be.visible');
-			cy.get('.editor-post-publish-panel__toggle').click();
-			cy.get('.components-panel__body:contains("Autoshare:")').should('exist');
-			cy.get('.components-panel__body:contains("Autoshare:")').click();
+			cy.openPrePublishPanel();
 
 			// Check enable checkbox for auto-share.
-			cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').should('be.visible');
-			cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').check();
+			cy.enableCheckbox('.autoshare-for-twitter-prepublish__checkbox input:checkbox', defaultBehavior, true);
 
 			// Publish.
 			cy.get('[aria-disabled="false"].editor-post-publish-button').should('be.visible');
@@ -87,7 +70,7 @@ describe('Test Autoshare for Twitter with Block Editor.', () => {
 			cy.get('.autoshare-for-twitter-post-status').contains('Tweeted on');
 		});
 
-		it.skip('Tests that Draft post is not tweeted when box is unchecked', () => {
+		it('Tests that Draft post is not tweeted when box is unchecked', () => {
 			// Start create new post by enter post title
 			cy.startCreatePost();
 
@@ -97,14 +80,10 @@ describe('Test Autoshare for Twitter with Block Editor.', () => {
 			cy.get('.editor-post-saved-state').should('have.text', 'Saved');
 
 			// Open pre-publish Panel.
-			cy.get('.editor-post-publish-panel__toggle').should('be.visible');
-			cy.get('.editor-post-publish-panel__toggle').click();
-			cy.get('.components-panel__body:contains("Autoshare:")').should('exist');
-			cy.get('.components-panel__body:contains("Autoshare:")').click();
+			cy.openPrePublishPanel();
 
 			// Uncheck enable checkbox for auto-share.
-			cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').should('be.visible');
-			cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').uncheck();
+			cy.enableCheckbox('.autoshare-for-twitter-prepublish__checkbox input:checkbox', defaultBehavior, false);
 
 			// Publish.
 			cy.get('[aria-disabled="false"].editor-post-publish-button').should('be.visible');
@@ -115,7 +94,7 @@ describe('Test Autoshare for Twitter with Block Editor.', () => {
 			cy.get('.autoshare-for-twitter-post-status').contains('This post was not tweeted.');
 		});
 
-		it.skip('Tests that Draft post is tweeted when box is checked', () => {
+		it('Tests that Draft post is tweeted when box is checked', () => {
 			// Start create new post by enter post title
 			cy.startCreatePost();
 
@@ -125,14 +104,10 @@ describe('Test Autoshare for Twitter with Block Editor.', () => {
 			cy.get('.editor-post-saved-state').should('have.text', 'Saved');
 
 			// Open pre-publish Panel.
-			cy.get('.editor-post-publish-panel__toggle').should('be.visible');
-			cy.get('.editor-post-publish-panel__toggle').click();
-			cy.get('.components-panel__body:contains("Autoshare:")').should('exist');
-			cy.get('.components-panel__body:contains("Autoshare:")').click();
+			cy.openPrePublishPanel();
 
 			// Check enable checkbox for auto-share.
-			cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').should('be.visible');
-			cy.get('.autoshare-for-twitter-prepublish__checkbox input:checkbox').check();
+			cy.enableCheckbox('.autoshare-for-twitter-prepublish__checkbox input:checkbox', defaultBehavior, true);
 
 			// Publish.
 			cy.get('[aria-disabled="false"].editor-post-publish-button').should('be.visible');

--- a/tests/cypress/integration/classic-editor.test.js
+++ b/tests/cypress/integration/classic-editor.test.js
@@ -24,15 +24,12 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 			cy.get('#submit').click();
 		});
 
-		it('Tests that new post is not tweeted when box is unchecked', () => {
+		it.skip('Tests that new post is not tweeted when box is unchecked', () => {
 			// Start create post.
 			cy.classicStartCreatePost();
 
-			// Checkbox
-			const isChecked = defaultBehavior ? 'be.checked' : 'not.be.checked';
-			cy.get('#autoshare-for-twitter-enable').should('exist');
-			cy.get('#autoshare-for-twitter-enable').should(isChecked);
-			cy.get('#autoshare-for-twitter-enable').uncheck();
+			// Check enable checkbox for auto-share.
+			cy.enableCheckbox('#autoshare-for-twitter-enable', defaultBehavior, false);
 
 			// publish
 			cy.get('#publish').click();
@@ -44,13 +41,12 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 		});
 
 
-		it('Tests that new post is tweeted when box is checked', () => {
+		it.skip('Tests that new post is tweeted when box is checked', () => {
 			// Start create post.
 			cy.classicStartCreatePost();	
 
-			// Checkbox
-			const isChecked = defaultBehavior ? 'be.checked' : 'not.be.checked';
-			cy.get('#autoshare-for-twitter-enable').should('exist').should(isChecked).check();
+			// Check enable checkbox for auto-share.
+			cy.enableCheckbox('#autoshare-for-twitter-enable', defaultBehavior, true);
 			cy.get('#publish').click();
 
 			// Post-publish.
@@ -67,10 +63,7 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 			cy.get('#save-post').click();
 
 			// Uncheck the checkbox and publish
-			const isChecked = defaultBehavior ? 'be.checked' : 'not.be.checked';
-			cy.get('#autoshare-for-twitter-enable').should('exist');
-			cy.get('#autoshare-for-twitter-enable').should(isChecked);
-			cy.get('#autoshare-for-twitter-enable').uncheck();
+			cy.enableCheckbox('#autoshare-for-twitter-enable', defaultBehavior, false);
 			cy.get('#publish').click();
 
 			// Post-publish.
@@ -86,11 +79,8 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 			// Save Draft
 			cy.get('#save-post').click();
 			
-			// Uncheck the checkbox and publish
-			const isChecked = defaultBehavior ? 'be.checked' : 'not.be.checked';
-			cy.get('#autoshare-for-twitter-enable').should('exist');
-			cy.get('#autoshare-for-twitter-enable').should(isChecked);
-			cy.get('#autoshare-for-twitter-enable').check();
+			// Check the checkbox and publish
+			cy.enableCheckbox('#autoshare-for-twitter-enable', defaultBehavior, true);
 			cy.get('#publish').click();
 
 			// Post-publish.

--- a/tests/cypress/integration/classic-editor.test.js
+++ b/tests/cypress/integration/classic-editor.test.js
@@ -24,7 +24,7 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 			cy.get('#submit').click();
 		});
 
-		it.skip('Tests that new post is not tweeted when box is unchecked', () => {
+		it('Tests that new post is not tweeted when box is unchecked', () => {
 			// Start create post.
 			cy.classicStartCreatePost();
 
@@ -41,7 +41,7 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 		});
 
 
-		it.skip('Tests that new post is tweeted when box is checked', () => {
+		it('Tests that new post is tweeted when box is checked', () => {
 			// Start create post.
 			cy.classicStartCreatePost();	
 

--- a/tests/cypress/integration/classic-editor.test.js
+++ b/tests/cypress/integration/classic-editor.test.js
@@ -11,13 +11,13 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 	});
 
 	// Run test cases with default Autoshare enabled and disabled both.
-	const defaultBehaviors = [true, false];
+	const defaultBehaviors = [false, true];
 	defaultBehaviors.forEach( (defaultBehavior) => {	
 		it(`Can ${(defaultBehavior ? 'Enable': 'Disable')} default Autoshare`, () => {
 			cy.visit('/wp-admin/options-general.php?page=autoshare-for-twitter');
 			cy.get('input:checkbox[name="autoshare-for-twitter[enable_default]"]').should('exist');
 			if (true === defaultBehavior) {
-				cy.get('input:checkbox[name="autoshare-for-twitter[enable_default]"]').uncheck();
+				cy.get('input:checkbox[name="autoshare-for-twitter[enable_default]"]').check();
 			} else {
 				cy.get('input:checkbox[name="autoshare-for-twitter[enable_default]"]').uncheck();
 			}
@@ -27,6 +27,12 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 		it('Tests that new post is not tweeted when box is unchecked', () => {
 			// Start create post.
 			cy.classicStartCreatePost();
+
+			// Checkbox
+			const isChecked = defaultBehavior ? 'be.checked' : 'not.be.checked';
+			cy.get('#autoshare-for-twitter-enable').should('exist');
+			cy.get('#autoshare-for-twitter-enable').should(isChecked);
+			cy.get('#autoshare-for-twitter-enable').uncheck();
 
 			// publish
 			cy.get('#publish').click();
@@ -43,8 +49,8 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 			cy.classicStartCreatePost();	
 
 			// Checkbox
-			cy.get('#autoshare-for-twitter-enable').should('exist');
-			cy.get('#autoshare-for-twitter-enable').check();
+			const isChecked = defaultBehavior ? 'be.checked' : 'not.be.checked';
+			cy.get('#autoshare-for-twitter-enable').should('exist').should(isChecked).check();
 			cy.get('#publish').click();
 
 			// Post-publish.
@@ -61,7 +67,9 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 			cy.get('#save-post').click();
 
 			// Uncheck the checkbox and publish
+			const isChecked = defaultBehavior ? 'be.checked' : 'not.be.checked';
 			cy.get('#autoshare-for-twitter-enable').should('exist');
+			cy.get('#autoshare-for-twitter-enable').should(isChecked);
 			cy.get('#autoshare-for-twitter-enable').uncheck();
 			cy.get('#publish').click();
 
@@ -78,8 +86,10 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 			// Save Draft
 			cy.get('#save-post').click();
 			
-			// Check the checkbox and publish
+			// Uncheck the checkbox and publish
+			const isChecked = defaultBehavior ? 'be.checked' : 'not.be.checked';
 			cy.get('#autoshare-for-twitter-enable').should('exist');
+			cy.get('#autoshare-for-twitter-enable').should(isChecked);
 			cy.get('#autoshare-for-twitter-enable').check();
 			cy.get('#publish').click();
 

--- a/tests/cypress/integration/classic-editor.test.js
+++ b/tests/cypress/integration/classic-editor.test.js
@@ -10,67 +10,82 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 		cy.get('#submit').click();
 	});
 
-	it('Tests that new post is not tweeted when box is unchecked', () => {
-		// Start create post.
-		cy.classicStartCreatePost();
+	// Run test cases with default Autoshare enabled and disabled both.
+	const defaultBehaviors = [true, false];
+	defaultBehaviors.forEach( (defaultBehavior) => {	
+		it(`Can ${(defaultBehavior ? 'Enable': 'Disable')} default Autoshare`, () => {
+			cy.visit('/wp-admin/options-general.php?page=autoshare-for-twitter');
+			cy.get('input:checkbox[name="autoshare-for-twitter[enable_default]"]').should('exist');
+			if (true === defaultBehavior) {
+				cy.get('input:checkbox[name="autoshare-for-twitter[enable_default]"]').uncheck();
+			} else {
+				cy.get('input:checkbox[name="autoshare-for-twitter[enable_default]"]').uncheck();
+			}
+			cy.get('#submit').click();
+		});
 
-		// publish
-		cy.get('#publish').click();
-		cy.get('#wpadminbar').should('be.visible');
+		it('Tests that new post is not tweeted when box is unchecked', () => {
+			// Start create post.
+			cy.classicStartCreatePost();
 
-		// Post-publish.
-		cy.get('#autoshare_for_twitter_metabox').should('be.visible');
-		cy.get('#autoshare_for_twitter_metabox').contains('This post was not tweeted');
-	});
+			// publish
+			cy.get('#publish').click();
+			cy.get('#wpadminbar').should('be.visible');
 
-
-	it('Tests that new post is tweeted when box is checked', () => {
-		// Start create post.
-		cy.classicStartCreatePost();	
-
-		// Checkbox
-		cy.get('#autoshare-for-twitter-enable').should('exist');
-		cy.get('#autoshare-for-twitter-enable').check();
-		cy.get('#publish').click();
-
-		// Post-publish.
-		cy.get('#autoshare_for_twitter_metabox',).should('be.visible');
-		cy.get('#autoshare_for_twitter_metabox',).contains('Tweeted on');
-	});
-
-
-	it('Tests that draft post is not tweeted when box is unchecked', () => {
-		// Start create post.
-		cy.classicStartCreatePost();
-		
-		// Save Draft
-		cy.get('#save-post').click();
-
-		// Uncheck the checkbox and publish
-		cy.get('#autoshare-for-twitter-enable').should('exist');
-		cy.get('#autoshare-for-twitter-enable').uncheck();
-		cy.get('#publish').click();
-
-		// Post-publish.
-		cy.get('#autoshare_for_twitter_metabox').should('be.visible');
-		cy.get('#autoshare_for_twitter_metabox').contains('This post was not tweeted');
-	});
+			// Post-publish.
+			cy.get('#autoshare_for_twitter_metabox').should('be.visible');
+			cy.get('#autoshare_for_twitter_metabox').contains('This post was not tweeted');
+		});
 
 
-	it('Tests that draft post is tweeted when box is checked', () => {
-		// Start create post.
-		cy.classicStartCreatePost();
+		it('Tests that new post is tweeted when box is checked', () => {
+			// Start create post.
+			cy.classicStartCreatePost();	
 
-		// Save Draft
-		cy.get('#save-post').click();
-		
-		// Check the checkbox and publish
-		cy.get('#autoshare-for-twitter-enable').should('exist');
-		cy.get('#autoshare-for-twitter-enable').check();
-		cy.get('#publish').click();
+			// Checkbox
+			cy.get('#autoshare-for-twitter-enable').should('exist');
+			cy.get('#autoshare-for-twitter-enable').check();
+			cy.get('#publish').click();
 
-		// Post-publish.
-		cy.get('#autoshare_for_twitter_metabox').should('be.visible');
-		cy.get('#autoshare_for_twitter_metabox').contains('Tweeted on');
+			// Post-publish.
+			cy.get('#autoshare_for_twitter_metabox',).should('be.visible');
+			cy.get('#autoshare_for_twitter_metabox',).contains('Tweeted on');
+		});
+
+
+		it('Tests that draft post is not tweeted when box is unchecked', () => {
+			// Start create post.
+			cy.classicStartCreatePost();
+			
+			// Save Draft
+			cy.get('#save-post').click();
+
+			// Uncheck the checkbox and publish
+			cy.get('#autoshare-for-twitter-enable').should('exist');
+			cy.get('#autoshare-for-twitter-enable').uncheck();
+			cy.get('#publish').click();
+
+			// Post-publish.
+			cy.get('#autoshare_for_twitter_metabox').should('be.visible');
+			cy.get('#autoshare_for_twitter_metabox').contains('This post was not tweeted');
+		});
+
+
+		it('Tests that draft post is tweeted when box is checked', () => {
+			// Start create post.
+			cy.classicStartCreatePost();
+
+			// Save Draft
+			cy.get('#save-post').click();
+			
+			// Check the checkbox and publish
+			cy.get('#autoshare-for-twitter-enable').should('exist');
+			cy.get('#autoshare-for-twitter-enable').check();
+			cy.get('#publish').click();
+
+			// Post-publish.
+			cy.get('#autoshare_for_twitter_metabox').should('be.visible');
+			cy.get('#autoshare_for_twitter_metabox').contains('Tweeted on');
+		});
 	});
 });

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -42,3 +42,35 @@ Cypress.Commands.add( 'classicStartCreatePost', () => {
 	let postTitle = getRandomText(8);
 	cy.get('input[name="post_title"]').type('Random Post Title' + postTitle );
 });
+
+Cypress.Commands.add( 'openPrePublishPanel', () => {
+	// Open pre-publish Panel.
+	cy.get('.editor-post-publish-panel__toggle').should('be.visible');
+	cy.get('.editor-post-publish-panel__toggle').click();
+	cy.get('.components-panel__body:contains("Autoshare:")').should('exist');
+	cy.get('.components-panel__body:contains("Autoshare:")').click();	
+});
+
+Cypress.Commands.add( 'enableCheckbox', ( checkboxSelector, defaultBehavior, check = true ) => {
+	// Check/Uncheck enable checkbox for auto-share.
+	cy.get(checkboxSelector).should('be.visible');
+	if (true === defaultBehavior) {
+		cy.get(checkboxSelector).should('be.checked');
+	} else {
+		cy.get(checkboxSelector).should('not.be.checked');
+	}
+	cy.intercept('**/autoshare/v1/post-autoshare-for-twitter-meta/*').as('enableCheckbox');
+	if (true === check) {
+		cy.get(checkboxSelector).check();
+		cy.wait('@enableCheckbox').then(response => {
+			expect(response.response?.body?.enabled).to.equal(check);
+		});
+		cy.get(checkboxSelector).should('be.checked');
+	} else {
+		cy.get(checkboxSelector).uncheck();
+		cy.wait('@enableCheckbox').then(response => {
+			expect(response.response?.body?.enabled).to.equal(check);
+		});
+		cy.get(checkboxSelector).should('not.be.checked');
+	}
+});

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -62,15 +62,19 @@ Cypress.Commands.add( 'enableCheckbox', ( checkboxSelector, defaultBehavior, che
 	cy.intercept('**/autoshare/v1/post-autoshare-for-twitter-meta/*').as('enableCheckbox');
 	if (true === check) {
 		cy.get(checkboxSelector).check();
-		cy.wait('@enableCheckbox').then(response => {
-			expect(response.response?.body?.enabled).to.equal(check);
-		});
+		if(defaultBehavior !== check){
+			cy.wait('@enableCheckbox').then(response => {
+				expect(response.response?.body?.enabled).to.equal(check);
+			});
+		}
 		cy.get(checkboxSelector).should('be.checked');
 	} else {
 		cy.get(checkboxSelector).uncheck();
-		cy.wait('@enableCheckbox').then(response => {
-			expect(response.response?.body?.enabled).to.equal(check);
-		});
+		if(defaultBehavior !== check){
+			cy.wait('@enableCheckbox').then(response => {
+				expect(response.response?.body?.enabled).to.equal(check);
+			});
+		}
 		cy.get(checkboxSelector).should('not.be.checked');
 	}
 });

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -47,6 +47,7 @@ Cypress.Commands.add( 'openPrePublishPanel', () => {
 	// Open pre-publish Panel.
 	cy.get('.editor-post-publish-panel__toggle').should('be.visible');
 	cy.get('.editor-post-publish-panel__toggle').click();
+	cy.wait(500); // prevent clicking on category assign suggestion panel. ToDo: find more proper way to handle this.
 	cy.get('.components-panel__body:contains("Autoshare:")').should('exist');
 	cy.get('.components-panel__body:contains("Autoshare:")').click();	
 });


### PR DESCRIPTION
### Description of the Change
As requested in #158, current E2E tests run with `Enable by default` option disabled. This PR made changes to run E2E tests with `Enable by default` checked and unchecked both to make sure it works as expected with both scenarios.

Closes #158 

### Alternate Designs

### Possible Drawbacks
### Verification Process
GH actions for E2E tests should `PASS`.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry
> Added - Some addtional E2E tests

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @iamdharmesh 
