### PR TITLE
Fixed incorrect `Tweet this post` checkbox behavior in the classic editor.

### DIFF
--- a/includes/admin/post-meta.php
+++ b/includes/admin/post-meta.php
@@ -140,7 +140,13 @@ function save_autoshare_for_twitter_meta_data( $post_id, $data ) {
 
 	// If the enable key is not set, set it to the default setting value.
 	if ( ! array_key_exists( ENABLE_AUTOSHARE_FOR_TWITTER_KEY, $data ) ) {
-		$data[ ENABLE_AUTOSHARE_FOR_TWITTER_KEY ] = autoshare_enabled( $post_id ) ? 1 : 0;
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( isset( $_POST['classic-editor'] ) ) {
+			// Handle unchecked "Tweet this post" checkbox for classic editor.
+			$data[ ENABLE_AUTOSHARE_FOR_TWITTER_KEY ] = 0;
+		} else {
+			$data[ ENABLE_AUTOSHARE_FOR_TWITTER_KEY ] = autoshare_enabled( $post_id ) ? 1 : 0;
+		}
 	}
 
 	foreach ( $data as $key => $value ) {


### PR DESCRIPTION
### Description of the Change
As described in #168, Currently, whenever we `Save draft` post with the `Tweet this post` checkbox checked, it always tweets post when we publish a post, even when we publish a post with the Tweet this post checkbox unchecked.

This is happening because when the checkbox is unchecked, it won't send with $_POST data and the plugin uses the existing value of the meta field (check [here](https://github.com/10up/autoshare-for-twitter/blob/develop/includes/admin/post-meta.php#L142-L144)). Which is enabled. So, the tweet is always get posted.

This PR contains changes to handle the unchecked "Tweet this post" checkbox for the classic editor and fix the reported issue. 

Closes #168 

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
1. Install the Classic Editor plugin.
2. Create a draft post in the classic editor (make sure the `Tweet this post` checkbox is checked).
3. Try to uncheck the checkbox and `Save draft`.
4. Verify checkbox is unchecked.
5. Check the checkbox and `Save draft`.
6. Uncheck the checkbox and `Publish` post.
7. Make sure the post is not tweeted.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->
> Fixed - Incorrect `Tweet this post` checkbox behavior in the classic editor.

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @iamdharmesh 
