### PR TITLE
Fix node cache to include Cypress

### DIFF
--- a/.github/workflows/build-release-zip.yml
+++ b/.github/workflows/build-release-zip.yml
@@ -32,7 +32,9 @@ jobs:
         env:
           cache-name: cache-node-modules
         with:
-          path: node_modules
+          path: |
+            - node_modules
+            - /home/runner/.cache/Cypress
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Setup node version and npm cache

--- a/.github/workflows/build-release-zip.yml
+++ b/.github/workflows/build-release-zip.yml
@@ -33,8 +33,9 @@ jobs:
           cache-name: cache-node-modules
         with:
           path: |
-            - node_modules
-            - /home/runner/.cache/Cypress
+            node_modules
+            ~/.cache
+            ~/.npm
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Setup node version and npm cache

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -49,8 +49,9 @@ jobs:
           cache-name: cache-node-modules
         with:
           path: |
-            - node_modules
-            - /home/runner/.cache/Cypress
+            node_modules
+            ~/.cache
+            ~/.npm
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install dependencies

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -8,10 +8,10 @@ on:
   pull_request:
     branches:
       - develop
-    paths:
-      - '**.js'
-      - '**.php'
-      - '**.css'
+    # paths:
+    #   - '**.js'
+    #   - '**.php'
+    #   - '**.css'
 
 jobs:
   build:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -8,10 +8,10 @@ on:
   pull_request:
     branches:
       - develop
-    # paths:
-    #   - '**.js'
-    #   - '**.php'
-    #   - '**.css'
+    paths:
+      - '**.js'
+      - '**.php'
+      - '**.css'
 
 jobs:
   build:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -48,7 +48,9 @@ jobs:
         env:
           cache-name: cache-node-modules
         with:
-          path: node_modules
+          path: |
+            - node_modules
+            - /home/runner/.cache/Cypress
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install dependencies


### PR DESCRIPTION
### Description of the Change

In #206, a node cache was introduced, but it did not include Cypress binaries. That's why, with the warm cache, cypress tasks failed.

The current PR fixes that by adding ~/.cache and ~/.npm to cached directories list.

Closes #211 

### How to test the Change
Tested with the following scenario:
1. Run the job for the first time (cold cache). See the cache is not exist, Cypress expected to run correctly. Cache should be created.
2. Re-run the job to test with warm cache. See the cache is downloaded and Cypress run correctly again (it was not before this change). Cache should not be overwritten.

I was forcing E2E tests to run by temporary disabling path filtering in https://github.com/10up/autoshare-for-twitter/pull/212/commits/4f7f1de4c2e7622413ef8ae5d96dd55e7bf98d41

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - E2E tests fail in the CI with warm cache 

### Credits
@cadic

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
