### PR TITLE
Show twitter status logs for the draft post if the post has been switched back to Draft from Published, and has already been Tweeted.

### DIFF
--- a/includes/admin/post-meta.php
+++ b/includes/admin/post-meta.php
@@ -275,6 +275,10 @@ function get_tweet_status_message( $post ) {
 	$post_status    = get_post_status( $post );
 	$response_array = array();
 
+	if ( empty( $post ) ) {
+		return [ 'message' => $response_array ];
+	}
+
 	$tweet_metas = Utils\get_autoshare_for_twitter_meta( $post->ID, TWITTER_STATUS_KEY );
 
 	if ( empty( $tweet_metas ) || isset( $tweet_metas['twitter_id'] ) ) {

--- a/src/js/AutoshareForTwitterPrePublishPanel.js
+++ b/src/js/AutoshareForTwitterPrePublishPanel.js
@@ -1,4 +1,5 @@
-import { Button, ToggleControl } from '@wordpress/components';
+import { Button, ToggleControl, ExternalLink, CardDivider } from '@wordpress/components';
+import { select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { TweetTextField } from './components/TweetTextField';
 import {
@@ -9,6 +10,7 @@ import {
 	useSaveTwitterData,
 	useHasFeaturedImage,
 } from './hooks';
+import { getIconByStatus } from './utils';
 
 export default function AutoshareForTwitterPrePublishPanel() {
 	const [ autoshareEnabled, setAutoshareEnabled ] = useTwitterAutoshareEnabled();
@@ -17,10 +19,23 @@ export default function AutoshareForTwitterPrePublishPanel() {
 	const [ errorMessage ] = useTwitterAutoshareErrorMessage();
 	const hasFeaturedImage = useHasFeaturedImage();
 
+	const messages = select( 'core/editor' ).getCurrentPostAttribute( 'autoshare_for_twitter_status' );
 	useSaveTwitterData();
 
 	return (
 		<>
+			{ messages && !!messages.message.length && ( <div className="autoshare-for-twitter-post-status">
+				{ messages.message.map( ( statusMessage, index ) => {
+					const TweetIcon = getIconByStatus( statusMessage.status );
+
+					return (
+						<div className="autoshare-for-twitter-log" key={ index }>
+							{ TweetIcon }{ statusMessage.url ? <ExternalLink href={ statusMessage.url }>{ statusMessage.message }</ExternalLink> : statusMessage.message }
+						</div>
+					);
+				} ) }
+				<CardDivider />
+			</div> ) }
 			<ToggleControl
 				label={ autoshareEnabled ? __( 'Tweet when published', 'autoshare-for-twitter' ) : __( 'Don\'t Tweet', 'autoshare-for-twitter' )
 				}


### PR DESCRIPTION
### Description of the Change
PR contains changes to Show Twitter status logs for the draft post if the post has been switched back to Draft from Published, and has already been Tweeted.

#### Gutenberg
| Before | After |
| --- | --- |
|![Screenshot 2023-01-05 at 12 04 35 PM](https://user-images.githubusercontent.com/10613171/210717030-98736890-db95-4b44-b9b9-72d3f20dbc85.png)|![Screenshot 2023-01-05 at 12 04 02 PM](https://user-images.githubusercontent.com/10613171/210717025-9c02ad8b-6392-465f-a427-7843beb8e8ce.png)|

#### Classic Editor
| Before | After |
| --- | --- |
|![Screenshot 2023-01-05 at 12 05 04 PM](https://user-images.githubusercontent.com/10613171/210717131-4a978924-c3ab-43a3-ac9a-15fe4ea0a927.png)|![Screenshot 2023-01-05 at 12 05 25 PM](https://user-images.githubusercontent.com/10613171/210717134-0a5dcb7f-93ca-4e87-a6dd-a6c21f957990.png)|

Closes #182

### How to test the Change
Need to test the following steps with Gutenberg and classic editor.

1. Create a post, publish it, and make sure it is tweeted.
2. Switch back post to `draft` from `published`
3. See the "Autotweet" document panel or the "Autoshare for Twitter" post metabox.
4. Twitter status log should be visible and the option for tweeting on publish should also be there.

### Changelog Entry
> Changed - Show twitter status logs for the draft post if the post has been switched back to Draft from Published, and has already been Tweeted.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @iamdharmesh @jeffpaul 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
