### PR TITLE
Made the saved Twitter keys obfuscated in the UI

### DIFF
--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -39,13 +39,38 @@ function admin_menu() {
 }
 
 /**
+ * Sanitize and validate user input.
+ *
+ * @param string $post The user input to sanitize and validate.
+ *
+ * @return array The sanitized and validated values.
+ */
+function sanitize_settings( $post ) {
+	$options = get_option( AT_SETTINGS );
+
+	// The post keys that should be secure.
+	$secure_keys = array( 'api_key', 'api_secret', 'access_token', 'access_secret' );
+	foreach ( $secure_keys as $key ) {
+		if ( ! empty( $post[ $key ] ) ) {
+			$value = sanitize_text_field( trim( $post[ $key ] ) );
+			// If the value contains '***', use the existing option value if available, else empty string.
+			if ( false !== stripos( $value, '***' ) ) {
+				$post[ $key ] = isset( $options[ $key ] ) ? $options[ $key ] : '';
+			}
+		}
+	}
+
+	return $post;
+}
+
+/**
  * Register section and settings
  *
  * @return void
  */
 function register_settings() {
 
-	register_setting( AT_GROUP, AT_SETTINGS );
+	register_setting( AT_GROUP, AT_SETTINGS, __NAMESPACE__ . '\sanitize_settings' );
 
 	// Register the general setting section.
 	add_settings_section(
@@ -207,6 +232,10 @@ function text_field_cb( $args ) {
 	$value       = isset( $options[ $key ] ) ? $options[ $key ] : '';
 	$class       = isset( $args['class'] ) ? $args['class'] : 'regular-text';
 	$placeholder = isset( $args['placeholder'] ) ? $args['placeholder'] : '';
+
+	// The post keys that should be secure.
+	$secure_keys = array( 'api_key', 'api_secret', 'access_token', 'access_secret' );
+	$value       = in_array( $key, $secure_keys, true ) ? Utils\mask_secure_values( $value ) : $value;
 	?>
 		<input type='text' class="<?php echo esc_attr( $class ); ?>" name=<?php echo esc_attr( $name ); ?> value="<?php echo esc_attr( $value ); ?>" placeholder="<?php echo esc_attr( $placeholder ); ?>">
 	<?php

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -385,3 +385,18 @@ function get_enabled_post_types() {
 	}
 	return get_autoshare_for_twitter_settings( 'post_types' );
 }
+
+/**
+ * Mask secure values.
+ *
+ * @param string $value Original value.
+ *
+ * @return string
+ */
+function mask_secure_values( $value ) {
+	$count  = strlen( $value );
+	$substr = substr( $value, -5 );
+	$return = str_pad( $substr, $count, '*', STR_PAD_LEFT );
+
+	return $return;
+}


### PR DESCRIPTION
### Description of the Change

Made the saved Twitter keys obfuscated in the UI, see #240 

Closes #240

### How to test the Change

1. Go to /wp-admin/options-general.php?page=autoshare-for-twitter
2. Save your Twitter credentials
3. Toggle open the 'Open connection settings' after save
4. Keys should be obfuscated

### Changelog Entry

> Added - Obfuscating saved Twitter keys


### Credits

Props @bmarshall511 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
