### PR TITLE
Improved error handing.

### DIFF
--- a/includes/admin/post-transition.php
+++ b/includes/admin/post-transition.php
@@ -138,9 +138,19 @@ function publish_tweet( $post_id, $force = false ) {
 			$account  = $connected_accounts[ $account_id ] ?? [];
 			$username = $account['username'] ?? '';
 
-			$twitter_response = $publish->status_update( $tweet, $post, $account_id );
+			try {
+				$twitter_response = $publish->status_update( $tweet, $post, $account_id );
 
-			$response = validate_response( $twitter_response );
+				$response = validate_response( $twitter_response );
+			} catch ( \Exception $e ) {
+				$response = new \WP_Error(
+					'autoshare_for_twitter_failed',
+					esc_html__( 'Something went wrong, please try again.', 'autoshare-for-twitter' ),
+					array(
+						(object) array( 'message' => $e->getMessage() ),
+					)
+				);
+			}
 
 			if ( ! is_wp_error( $response ) ) {
 				update_autoshare_for_twitter_meta_from_response( $post->ID, $response, $username );


### PR DESCRIPTION
### Description of the Change
As reported in #243, Currently when we get any errors from TwitterOAuth PHP lib, it wont showing properly. This PR fix this issue and display proper error with keep status of failure.

![image](https://github.com/10up/autoshare-for-twitter/assets/10613171/7c447e23-5d76-4d84-82aa-cc5c3815ecfb)
 

Closes #243 

### How to test the Change
1. Manually throw error in any of Twitter status update function OR Stop the internet connection
2. Go to create a new post, Enable autoTweet on post, Publish post
3. Verify error message recorded in Twitter status there with failure.
4. Try Tweet Now functionality, and verify that it also properly save status with failure message.

### Changelog Entry
> Changed - Improved error handing.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
