### PR TITLE
Display connection notice only once.

### DIFF
--- a/includes/class-twitter-accounts.php
+++ b/includes/class-twitter-accounts.php
@@ -203,7 +203,7 @@ class Twitter_Accounts {
 	 * @return void
 	 */
 	public function twitter_connection_notices() {
-		$notice = get_transient( 'autoshare_for_twitter_connection_notice' );
+		$notice = $this->get_connection_notice();
 		if ( ! $notice ) {
 			return;
 		}
@@ -236,15 +236,12 @@ class Twitter_Accounts {
 
 	/**
 	 * Get connection notice.
-	 *
-	 * @param string $type    Notice type.
-	 * @param string $message Notice message.
 	 */
-	public function get_connection_notice( $type, $message ) {
-		$notices = get_transient( 'autoshare_for_twitter_connection_notice' );
+	public function get_connection_notice() {
+		$notice = get_transient( 'autoshare_for_twitter_connection_notice' );
 		delete_transient( 'autoshare_for_twitter_connection_notice' );
 
-		return $notices;
+		return $notice;
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change
We are showing connection notices by storing it in transient, the expiry time for transient is 30 secs. This PR updates the get connection notice logic by utilizing the `get_connection_notice` function instead of getting it directly using the `get_transient` function.  `get_connection_notice` function deletes the transient after getting it. So, the connection notice is displayed only once. while as per the current setup, it keeps showing till 30 secs

### How to test the Change
1. Configure the plugin by saving Twitter app credentials
2. Connect your Twitter account
3. You will see the connection notice for a successful connection.
4. Go to any other wp-admin page within 30 secs and verify that the connection notice is no longer visible.

### Changelog Entry
N/A


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
