### PR TITLE
Improved setup Instructions and error handing

### DIFF
--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -381,10 +381,8 @@ function cred_section_cb() {
 					?>
 				</li>
 				<li><?php esc_html_e( 'Switch from the "Settings" tab to the "Keys and tokens" tab.', 'autoshare-for-twitter' ); ?></li>
-				<li><?php echo wp_kses_data( __( 'Click on the <code>Generate</code> button in the <code>API Key and Secret</code> section.', 'autoshare-for-twitter' ) ); ?></li>
+				<li><?php echo wp_kses_data( __( 'Click on the <code>Generate</code>/<code>Regenerate</code> button in the <code>Consumer Keys</code> section.', 'autoshare-for-twitter' ) ); ?></li>
 				<li><?php echo wp_kses_data( __( 'Copy the <code>API Key</code> and <code>API Key Secret</code> values and paste them below.', 'autoshare-for-twitter' ) ); ?></li>
-				<li><?php echo wp_kses_data( __( 'Click on the <code>Generate</code> button in the <code>Access Token and Secret</code> section.', 'autoshare-for-twitter' ) ); ?></li>
-				<li><?php echo wp_kses_data( __( 'Copy the <code>Access Token</code> and <code>Access Token Secret</code> values and paste them below.', 'autoshare-for-twitter' ) ); ?></li>
 			</ul>
 
 			<h4><?php esc_html_e( '3. Save settings', 'autoshare-for-twitter' ); ?></h4>

--- a/includes/class-twitter-api.php
+++ b/includes/class-twitter-api.php
@@ -45,13 +45,6 @@ class Twitter_API {
 	protected $access_token_secret;
 
 	/**
-	 * The twitter handle.
-	 *
-	 * @var string The twitter handle.
-	 */
-	protected $twitter_handle;
-
-	/**
 	 * The TwitterOAuth client.
 	 *
 	 * @var TwitterOAuth The TwitterOAuth client.
@@ -172,6 +165,9 @@ class Twitter_API {
 		);
 
 		if ( ! $user || ! isset( $user->data ) || ! isset( $user->data->id ) ) {
+			if ( ! empty( $user->detail ) ) {
+				return new \WP_Error( 'error_get_twitter_user', $user->detail );
+			}
 			return new \WP_Error( 'error_get_twitter_user', __( 'Something went wrong during getting user details', 'autoshare-for-twitter' ) );
 		}
 


### PR DESCRIPTION
### Description of the Change
PR fixes the setup instructions to make it more clear and also updates the error message to be from Twitter API if it is available to give more clarity to users on what's wrong with their setup.

Closes #253 

### How to test the Change
1. Go to `Settings` > `Autoshare for Twitter`
1. Verify that setup instructions are updated as suggested in the issue.
1. Add some old app credentials to connection settings.
1. Try to connect Twitter account, and verify that you get an error notice from Twitter API instead of the standard "Something went wrong" error.

### Changelog Entry
> Changed - Improved setup Instructions and error handing


### Credits
Props @johnwatkins0 @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
