### PR TITLE
Fixed custom tweet message to make it work with scheduled posts. 

### DIFF
--- a/assets/js/admin-autoshare-for-twitter-classic-editor.js
+++ b/assets/js/admin-autoshare-for-twitter-classic-editor.js
@@ -238,6 +238,9 @@
 				( ( response.success && response.data.message ) || ( false === response.success && false === response.data.is_retweeted) )
 			) {
 				$('.autoshare-for-twitter-status-logs-wrapper').html(response.data.message);
+				if ( response.data.is_retweeted ) {
+					$tweetText.val(''); // Reset the tweet text.
+				}
 			} else {
 				$("#autoshare-for-twitter-error-message").html(adminAutoshareForTwitter.unknownErrorText);
 			}

--- a/includes/admin/assets.php
+++ b/includes/admin/assets.php
@@ -206,6 +206,7 @@ function localize_data( $handle = SCRIPT_HANDLE ) {
 	$status_meta    = get_autoshare_for_twitter_meta( $post_id, TWITTER_STATUS_KEY );
 	$accounts       = ( new Twitter_Accounts() )->get_twitter_accounts( true );
 	$tweet_accounts = get_tweet_accounts( $post_id );
+	$tweet_body     = trim( get_autoshare_for_twitter_meta( $post_id, TWEET_BODY_KEY ) );
 	if ( empty( $tweet_accounts ) ) {
 		$tweet_accounts = get_default_autoshare_accounts();
 	}
@@ -217,6 +218,7 @@ function localize_data( $handle = SCRIPT_HANDLE ) {
 		'nonce'              => wp_create_nonce( 'wp_rest' ),
 		'restUrl'            => rest_url( post_autoshare_for_twitter_meta_rest_route( $post_id ) ),
 		'tweetBodyKey'       => TWEET_BODY_KEY,
+		'customTweetBody'    => $tweet_body,
 		'status'             => $status_meta && is_array( $status_meta ) ? $status_meta : null,
 		'unknownErrorText'   => __( 'An unknown error occurred', 'autoshare-for-twitter' ),
 		'siteUrl'            => home_url(),

--- a/includes/admin/post-meta.php
+++ b/includes/admin/post-meta.php
@@ -546,6 +546,8 @@ function markup_unknown( $status_meta ) {
  * @return string
  */
 function _safe_markup_default() {
+	$custom_tweet_body = Utils\get_autoshare_for_twitter_meta( get_the_ID(), TWEET_BODY_KEY );
+
 	$count      = ( strlen( get_permalink( get_the_ID() ) ) + 5 );
 	$max_length = 280 - $count;
 	ob_start();
@@ -560,7 +562,9 @@ function _safe_markup_default() {
 		>
 		<span id="autoshare-for-twitter-icon" class="dashicons-before dashicons-twitter"></span>
 		<?php esc_html_e( 'Tweet this post', 'autoshare-for-twitter' ); ?>
-		<a href="#edit_tweet_text" id="autoshare-for-twitter-edit"><?php esc_html_e( 'Edit', 'autoshare-for-twitter' ); ?></a>
+		<a href="#edit_tweet_text" id="autoshare-for-twitter-edit" style="<?php echo ( ( ! empty( $custom_tweet_body ) ) ? 'display: none;' : '' ); ?>">
+			<?php esc_attr_e( 'Edit', 'autoshare-for-twitter' ); ?>
+		</a>
 	</label>
 
 	<div class="autoshare-for-twitter-tweet-allow-image-wrap" style="display: none;">
@@ -583,7 +587,7 @@ function _safe_markup_default() {
 	render_twitter_accounts( get_the_ID() );
 	?>
 
-	<div id="autoshare-for-twitter-override-body" style="display: none;">
+	<div id="autoshare-for-twitter-override-body" style="<?php echo ( ( empty( $custom_tweet_body ) ) ? 'display: none;' : '' ); ?>">
 		<label for="<?php echo esc_attr( sprintf( '%s[%s]', META_PREFIX, TWEET_BODY_KEY ) ); ?>">
 			<?php esc_html_e( 'Custom Message', 'autoshare-for-twitter' ); ?>:
 		</label>
@@ -593,7 +597,7 @@ function _safe_markup_default() {
 			name="<?php echo esc_attr( sprintf( '%s[%s]', META_PREFIX, TWEET_BODY_KEY ) ); ?>"
 			rows="3"
 			maxlength="<?php echo esc_attr( $max_length ); ?>"
-		><?php echo esc_textarea( Utils\get_autoshare_for_twitter_meta( get_the_ID(), TWEET_BODY_KEY ) ); ?></textarea>
+		><?php echo esc_textarea( $custom_tweet_body ); ?></textarea>
 		<p class="howto" id="autoshare-for-twitter-text-desc"><?php esc_html_e( 'Character count is inclusive of the post permalink which will be included in the final tweet.', 'autoshare-for-twitter' ); ?></p>
 
 		<p><a href="#" class="hide-if-no-js cancel-tweet-text"><?php esc_html_e( 'Hide', 'autoshare-for-twitter' ); ?></a></p>

--- a/includes/admin/post-transition.php
+++ b/includes/admin/post-transition.php
@@ -19,6 +19,8 @@ use function TenUp\AutoshareForTwitter\Core\Post_Meta\save_tweet_meta;
 use function TenUp\AutoshareForTwitter\Utils\get_autoshare_for_twitter_meta;
 use function TenUp\AutoshareForTwitter\Core\Post_Meta\get_tweet_status_logs;
 
+use const TenUp\AutoshareForTwitter\Core\Post_Meta\TWEET_BODY_KEY;
+
 /**
  * Setup function.
  *
@@ -169,6 +171,12 @@ function publish_tweet( $post_id, $force = false ) {
 				do_action( 'autoshare_for_twitter_failed' );
 				$failed = true;
 			}
+		}
+
+		if ( ! $failed ) {
+			// Clear the tweet body on successful publishing to Twitter.
+			Utils\delete_autoshare_for_twitter_meta( $post->ID, TWEET_BODY_KEY );
+			remove_action( 'save_post', 'TenUp\AutoshareForTwitter\Core\Post_Meta\save_tweet_meta', 10 );
 		}
 
 		return ( ! $failed );

--- a/src/js/AutoshareForTwitterPostStatusInfo.js
+++ b/src/js/AutoshareForTwitterPostStatusInfo.js
@@ -5,13 +5,14 @@ import { withSelect, useSelect } from '@wordpress/data';
 import { Button, ToggleControl, Icon } from '@wordpress/components';
 import { TweetTextField } from './components/TweetTextField';
 import { TwitterAccounts } from './components/TwitterAccounts';
-import { useHasFeaturedImage, useAllowTweetImage, useSaveTwitterData } from './hooks';
+import { useHasFeaturedImage, useAllowTweetImage, useSaveTwitterData, useTweetText } from './hooks';
 
 import { StatusLogs } from './components/StatusLogs';
 
 export function AutoshareForTwitterPostStatusInfo() {
 	const hasFeaturedImage = useHasFeaturedImage();
 	const [ allowTweetImage, setAllowTweetImage ] = useAllowTweetImage();
+	const [ , setTweetText ] = useTweetText();
 	const [ reTweet, setReTweet ] = useState( false );
 	const [ tweetNow, setTweetNow ] = useState( false );
 	const { messages } = useSelect( ( select ) => {
@@ -41,6 +42,10 @@ export function AutoshareForTwitterPostStatusInfo() {
 
 		const { data } = await apiResponse.json();
 
+		// Clear the tweet text if the tweet was successful.
+		if ( data.is_retweeted ) {
+			setTweetText( '' );
+		}
 		setStatusMessages( data );
 		setReTweet( false );
 	};

--- a/src/js/components/TweetTextField.js
+++ b/src/js/components/TweetTextField.js
@@ -3,6 +3,7 @@ import { useSelect } from '@wordpress/data';
 import { siteUrl } from 'admin-autoshare-for-twitter';
 import { __, sprintf } from '@wordpress/i18n';
 import { useTweetText } from '../hooks';
+import { useEffect, useState } from '@wordpress/element';
 
 export function TweetTextField() {
 	const getPermalinkLength = ( select ) => {
@@ -46,6 +47,18 @@ export function TweetTextField() {
 
 	const [ tweetText, setTweetText ] = useTweetText();
 	const { tweetLength, overrideLengthClass } = getTweetLength();
+
+	const status = useSelect( ( __select ) =>  __select( 'core/editor' ).getEditedPostAttribute( 'status' ) );
+	const [ isPublished, setIsPublished ] = useState( status === 'publish' );
+
+	useEffect( () => {
+		if ( 'publish' !==  status || isPublished ) {
+			return;
+		}
+
+		setTweetText( '' );
+		setIsPublished( true );
+	}, [ status, isPublished ] );
 
 	const CounterTooltip = () => (
 		<Tooltip 

--- a/src/js/store/reducer.js
+++ b/src/js/store/reducer.js
@@ -1,4 +1,4 @@
-import { enabled, allowTweetImage, tweetAccounts } from 'admin-autoshare-for-twitter';
+import { enabled, allowTweetImage, tweetAccounts, customTweetBody } from 'admin-autoshare-for-twitter';
 
 import {
 	SET_AUTOSHARE_FOR_TWITTER_ENABLED,
@@ -15,9 +15,9 @@ export const DEFAULT_STATE = {
 	autoshareEnabled: ( ! ! enabled && '0' !== enabled ),
 	errorMessage: '',
 	loaded: false,
-	overriding: false,
+	overriding: customTweetBody ? true : false,
 	overrideLength: 0,
-	tweetText: '',
+	tweetText : customTweetBody || '',
 	allowTweetImage: ! ! allowTweetImage,
 	tweetAccounts: tweetAccounts || [],
 };

--- a/tests/cypress/e2e/block-editor.test.js
+++ b/tests/cypress/e2e/block-editor.test.js
@@ -183,4 +183,38 @@ describe('Test Autoshare for Twitter with Block Editor.', () => {
 			cy.get('.autoshare-for-twitter-log a').contains('Tweeted on');
 		});
 	});
+
+	it('Tests that custom tweet message remain persistent for Tweet', () => {
+		const customTweetBody = `Custom Tweet ${getRandomText(6)}`;
+		// Start create new post by enter post title
+		cy.startCreatePost();
+
+		// Open AutoTweet Panel and set custom tweet message.
+		cy.openDocumentSettingsPanel('Autotweet enabled');
+		cy.get('.autoshare-for-twitter-prepublish__override-row button').click();
+		cy.get('.autoshare-for-twitter-tweet-text textarea').clear().type(customTweetBody);
+
+		// Save Draft
+		cy.get('.editor-post-save-draft').should('be.visible');
+		cy.get('.editor-post-save-draft').click();
+		cy.get('.editor-post-saved-state').should('have.text', 'Saved');
+
+		// Verify custom tweet message.
+		cy.reload();
+		cy.get('.autoshare-for-twitter-tweet-text textarea').should('have.value', customTweetBody);
+
+		// Open pre-publish Panel.
+		cy.openPrePublishPanel();
+
+		// Publish
+		cy.publishPost();
+
+		// Post-publish.
+		cy.get('.autoshare-for-twitter-post-status').should('be.visible');
+		cy.get('.autoshare-for-twitter-post-status').contains('Tweeted on');
+
+		// Verify custom tweet message is cleared on publish.
+		cy.get('.post-publish-panel__postpublish button.autoshare-for-twitter-tweet-now').click();
+		cy.get('.post-publish-panel__postpublish .autoshare-for-twitter-tweet-text textarea').should('have.value', '');
+	});
 });

--- a/tests/cypress/e2e/classic-editor.test.js
+++ b/tests/cypress/e2e/classic-editor.test.js
@@ -148,4 +148,32 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 			cy.get('.autoshare-for-twitter-status-log-data').contains('Tweeted on');
 		});
 	});
+
+	it('Tests that custom tweet message remain persistent for Tweet', () => {
+		const customTweetBody = `Custom Tweet ${getRandomText(6)}`;
+		// Start create post.
+		cy.classicStartCreatePost();
+
+		// Set custom tweet message.
+		cy.enableCheckbox('#autoshare-for-twitter-enable', true, true);
+		cy.get('#autoshare-for-twitter-edit').click();
+		cy.get('textarea#autoshare-for-twitter-text').clear().type(customTweetBody);
+
+		// Save Draft
+		cy.get('#save-post').click();
+
+		// verify custom tweet message.
+		cy.get('textarea#autoshare-for-twitter-text').should('have.value', customTweetBody);
+
+		// publish
+		cy.get('#publish').should('be.visible').click({force: true});
+
+		// Post-publish.
+		cy.get('#autoshare_for_twitter_metabox',).should('be.visible');
+		cy.get('#autoshare_for_twitter_metabox',).contains('Tweeted on');
+
+		// Verify custom tweet message is cleared on publish.
+		cy.get('button.tweet-now-button').click();
+		cy.get('textarea#autoshare-for-twitter-text').should('have.value', '');
+	});
 });

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -110,7 +110,7 @@ Cypress.Commands.add( 'markAccountForAutoshare', ( enable = true ) => {
 Cypress.Commands.add( 'enableEditor', ( editor = 'block' ) => {
 	cy.visit('/wp-admin/options-writing.php#classic-editor-options');
 		cy.get(`#classic-editor-${editor}`).click();
-		cy.get('#classic-editor-allow').click();
+		cy.get('#classic-editor-disallow').click();
 		cy.get('#submit').click();
 });
 


### PR DESCRIPTION
### Description of the Change
As reported in #263, Custom tweet messages don't remain persistent in posts. So, when we set a custom tweet message and schedule it for publish in the future, it just sends the generic tweet, but not the Tweet from custom tweet message. PR fixes this issue.

Closes #263 

### How to test the Change
1. Create a post
1. Set custom tweet message and save post as draft
1. Refresh edit post page and verify that custom tweet message remain saved
1. schedule post to be publish in future
1. Verify that posted tweet is as per the custom tweet message when the scheduled post is scheduled.

### Changelog Entry
> Fixed - The custom tweet message does not work with scheduled posts. 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @GeoffLambert77 @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
