### PR TITLE
Fixed connected Twitter accounts visibility in the classic editor.

### DIFF
--- a/includes/admin/post-meta.php
+++ b/includes/admin/post-meta.php
@@ -293,8 +293,9 @@ function render_twitter_accounts( $post_id ) {
 	if ( empty( $enabled ) ) {
 		$enabled = Utils\get_default_autoshare_accounts();
 	}
+	$display = ( autoshare_enabled( $post_id ) ) ? '' : 'display: none;';
 	?>
-	<div class="autoshare-for-twitter-accounts-wrapper">
+	<div class="autoshare-for-twitter-accounts-wrapper" style="<?php echo esc_attr( $display ); ?>">
 		<?php
 		foreach ( $accounts as $account ) {
 			?>

--- a/includes/admin/post-meta.php
+++ b/includes/admin/post-meta.php
@@ -156,7 +156,7 @@ function save_autoshare_for_twitter_meta_data( $post_id, $data ) {
 	// If the enable key is not set, set it to the default setting value.
 	if ( ! array_key_exists( ENABLE_AUTOSHARE_FOR_TWITTER_KEY, $data ) ) {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
-		if ( isset( $_POST['classic-editor'] ) ) {
+		if ( isset( $_POST['autoshare-classic-editor'] ) ) {
 			// Handle unchecked "Tweet this post" checkbox for classic editor.
 			$data[ ENABLE_AUTOSHARE_FOR_TWITTER_KEY ] = 0;
 		} else {
@@ -166,7 +166,7 @@ function save_autoshare_for_twitter_meta_data( $post_id, $data ) {
 
 	if ( ! array_key_exists( TWEET_ALLOW_IMAGE, $data ) ) {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
-		if ( isset( $_POST['classic-editor'] ) ) {
+		if ( isset( $_POST['autoshare-classic-editor'] ) ) {
 			// Handle unchecked "Tweet this post" checkbox for classic editor.
 			$data[ TWEET_ALLOW_IMAGE ] = 0;
 		} else {
@@ -560,6 +560,7 @@ function _safe_markup_default() {
 			value="1"
 			<?php checked( autoshare_enabled( get_the_ID() ) ); ?>
 		>
+		<input type="hidden" name="autoshare-classic-editor" value="1" />
 		<span id="autoshare-for-twitter-icon" class="dashicons-before dashicons-twitter"></span>
 		<?php esc_html_e( 'Tweet this post', 'autoshare-for-twitter' ); ?>
 		<a href="#edit_tweet_text" id="autoshare-for-twitter-edit" style="<?php echo ( ( ! empty( $custom_tweet_body ) ) ? 'display: none;' : '' ); ?>">


### PR DESCRIPTION
### Description of the Change
During release-ready testing, I came across this minor issue of Twitter account visibility in the classic editor. when we disable AutoShare, connected accounts get hidden but on page refresh, it becomes visible again.

![Screenshot 2023-08-18 at 11 44 50 AM](https://github.com/10up/autoshare-for-twitter/assets/10613171/2b954a80-1aff-4df4-a45e-997d7a24b18f)

This PR fixes this issue and also adds a hidden field for identifying the request from the classic editor. 

### How to test the Change
1. Create a post with draft status
2. Disable Autoshare by unchecking the "Tweet this post" checkbox
3. Save the post (draft) and verify tweet accounts are not visible.
4. Refresh the page and verify that tweet accounts are not visible.
5. Enable Autoshare by checking the "Tweet this post" checkbox
6. Save the post (draft) and verify tweet accounts are visible.
7. Refresh the page and verify that tweet accounts are visible.

### Changelog Entry
> Fixed - Connected Twitter accounts visibility in the classic editor.


### Credits
Props @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
