### PR TITLE
Fixed Twitter accounts visibility in the classic editor.

### DIFF
--- a/includes/admin/post-meta.php
+++ b/includes/admin/post-meta.php
@@ -284,7 +284,8 @@ function render_tweet_submitbox( $post ) {
  * @param int $post_id The post ID.
  */
 function render_twitter_accounts( $post_id ) {
-	$accounts = ( new Twitter_Accounts() )->get_twitter_accounts( true );
+	$post_status = get_post_status( $post_id );
+	$accounts    = ( new Twitter_Accounts() )->get_twitter_accounts( true );
 	if ( empty( $accounts ) ) {
 		return;
 	}
@@ -293,7 +294,7 @@ function render_twitter_accounts( $post_id ) {
 	if ( empty( $enabled ) ) {
 		$enabled = Utils\get_default_autoshare_accounts();
 	}
-	$display = ( autoshare_enabled( $post_id ) ) ? '' : 'display: none;';
+	$display = ( autoshare_enabled( $post_id ) || 'publish' === $post_status ) ? '' : 'display: none;';
 	?>
 	<div class="autoshare-for-twitter-accounts-wrapper" style="<?php echo esc_attr( $display ); ?>">
 		<?php


### PR DESCRIPTION
### Description of the Change
As reported in #276, currently the Twitter accounts are hidden in the "Tweet Now" meta box. This PR fixes that issue.

Closes #276

### How to test the Change
Detailed reproduce steps are given in issue #276

### Changelog Entry
> Fixed - Issue with Twitter accounts visibility in the classic editor.


### Credits
Props @iamdharmesh 


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
