### PR TITLE
Upgrade Cypress to version 13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 				"@wordpress/api-fetch": "^3.5.0"
 			},
 			"devDependencies": {
-				"@10up/cypress-wp-utils": "^0.1.0",
+				"@10up/cypress-wp-utils": "^0.2.0",
 				"@10up/eslint-config": "^1.0.9",
 				"@babel/core": "^7.6.0",
 				"@babel/preset-env": "^7.6.0",
@@ -21,7 +21,7 @@
 				"@wordpress/prettier-config": "^1.1.1",
 				"babel-eslint": "^10.0.3",
 				"babel-loader": "^8.0.6",
-				"cypress": "^11.2.0",
+				"cypress": "^13.0.0",
 				"cypress-iframe": "^1.0.1",
 				"cypress-mochawesome-reporter": "^3.5.1",
 				"eslint": "^6.3.0",
@@ -34,9 +34,9 @@
 			}
 		},
 		"node_modules/@10up/cypress-wp-utils": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.1.0.tgz",
-			"integrity": "sha512-6yige9N0kqG0XM4HBQBPcr2k7TwUV+4PLESvQEvsDyIkvRvLzL1Fnbork+s1+hvni+2qL6Ghjhjjd2npTNbqRg==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.2.0.tgz",
+			"integrity": "sha512-5gzamtHIFojT+wx0OzSAEeVY6FVrlcVPHVFH23uExkaqQhNsJvrnpdtqtT98wAYkXg56c1qDN7Ju7ZRTaNzP5g==",
 			"dev": true,
 			"engines": {
 				"node": ">=12.0"
@@ -1962,9 +1962,9 @@
 			}
 		},
 		"node_modules/@cypress/request": {
-			"version": "2.88.12",
-			"resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-			"integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.0.tgz",
+			"integrity": "sha512-GKFCqwZwMYmL3IBoNeR2MM1SnxRIGERsQOTWeQKoYBt2JLqcqiy7JXqO894FLrpjZYqGxW92MNwRH2BN56obdQ==",
 			"dev": true,
 			"dependencies": {
 				"aws-sign2": "~0.7.0",
@@ -3846,9 +3846,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "14.18.32",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.32.tgz",
-			"integrity": "sha512-Y6S38pFr04yb13qqHf8uk1nHE3lXgQ30WZbv1mLliV9pt0NjvqdWttLcrOYLnXbOafknVYRHZGoMSpR9UwfYow=="
+			"version": "16.18.46",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.46.tgz",
+			"integrity": "sha512-Mnq3O9Xz52exs3mlxMcQuA7/9VFe/dXcrgAyfjLkABIqxXKOgBRjyazTxUbjsxDa4BP7hhPliyjVTP9RDP14xg=="
 		},
 		"node_modules/@types/normalize-package-data": {
 			"version": "2.4.1",
@@ -4802,9 +4802,9 @@
 			}
 		},
 		"node_modules/aws4": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+			"integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
 			"dev": true
 		},
 		"node_modules/axe-core": {
@@ -5722,9 +5722,9 @@
 			"peer": true
 		},
 		"node_modules/commander": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-			"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
 			"dev": true,
 			"engines": {
 				"node": ">= 6"
@@ -5987,15 +5987,15 @@
 			}
 		},
 		"node_modules/cypress": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-			"integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
+			"integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
-				"@cypress/request": "^2.88.10",
+				"@cypress/request": "^3.0.0",
 				"@cypress/xvfb": "^1.2.4",
-				"@types/node": "^14.14.31",
+				"@types/node": "^16.18.39",
 				"@types/sinonjs__fake-timers": "8.1.1",
 				"@types/sizzle": "^2.3.2",
 				"arch": "^2.2.0",
@@ -6007,10 +6007,10 @@
 				"check-more-types": "^2.24.0",
 				"cli-cursor": "^3.1.0",
 				"cli-table3": "~0.6.1",
-				"commander": "^5.1.0",
+				"commander": "^6.2.1",
 				"common-tags": "^1.8.0",
 				"dayjs": "^1.10.4",
-				"debug": "^4.3.2",
+				"debug": "^4.3.4",
 				"enquirer": "^2.3.6",
 				"eventemitter2": "6.4.7",
 				"execa": "4.1.0",
@@ -6025,12 +6025,13 @@
 				"listr2": "^3.8.3",
 				"lodash": "^4.17.21",
 				"log-symbols": "^4.0.0",
-				"minimist": "^1.2.6",
+				"minimist": "^1.2.8",
 				"ospath": "^1.2.2",
 				"pretty-bytes": "^5.6.0",
+				"process": "^0.11.10",
 				"proxy-from-env": "1.0.0",
 				"request-progress": "^3.0.0",
-				"semver": "^7.3.2",
+				"semver": "^7.5.3",
 				"supports-color": "^8.1.1",
 				"tmp": "~0.2.1",
 				"untildify": "^4.0.0",
@@ -6040,7 +6041,7 @@
 				"cypress": "bin/cypress"
 			},
 			"engines": {
-				"node": ">=12.0.0"
+				"node": "^16.0.0 || ^18.0.0 || >=20.0.0"
 			}
 		},
 		"node_modules/cypress-iframe": {
@@ -6178,9 +6179,9 @@
 			}
 		},
 		"node_modules/cypress/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -11820,9 +11821,9 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -13677,6 +13678,15 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6.0"
 			}
 		},
 		"node_modules/process-nextick-args": {
@@ -16873,9 +16883,9 @@
 	},
 	"dependencies": {
 		"@10up/cypress-wp-utils": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.1.0.tgz",
-			"integrity": "sha512-6yige9N0kqG0XM4HBQBPcr2k7TwUV+4PLESvQEvsDyIkvRvLzL1Fnbork+s1+hvni+2qL6Ghjhjjd2npTNbqRg==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.2.0.tgz",
+			"integrity": "sha512-5gzamtHIFojT+wx0OzSAEeVY6FVrlcVPHVFH23uExkaqQhNsJvrnpdtqtT98wAYkXg56c1qDN7Ju7ZRTaNzP5g==",
 			"dev": true
 		},
 		"@10up/eslint-config": {
@@ -18171,9 +18181,9 @@
 			"optional": true
 		},
 		"@cypress/request": {
-			"version": "2.88.12",
-			"resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-			"integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.0.tgz",
+			"integrity": "sha512-GKFCqwZwMYmL3IBoNeR2MM1SnxRIGERsQOTWeQKoYBt2JLqcqiy7JXqO894FLrpjZYqGxW92MNwRH2BN56obdQ==",
 			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
@@ -19673,9 +19683,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.18.32",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.32.tgz",
-			"integrity": "sha512-Y6S38pFr04yb13qqHf8uk1nHE3lXgQ30WZbv1mLliV9pt0NjvqdWttLcrOYLnXbOafknVYRHZGoMSpR9UwfYow=="
+			"version": "16.18.46",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.46.tgz",
+			"integrity": "sha512-Mnq3O9Xz52exs3mlxMcQuA7/9VFe/dXcrgAyfjLkABIqxXKOgBRjyazTxUbjsxDa4BP7hhPliyjVTP9RDP14xg=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.1",
@@ -20447,9 +20457,9 @@
 			"dev": true
 		},
 		"aws4": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+			"integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
 			"dev": true
 		},
 		"axe-core": {
@@ -21138,9 +21148,9 @@
 			"peer": true
 		},
 		"commander": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-			"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
 			"dev": true
 		},
 		"comment-parser": {
@@ -21362,14 +21372,14 @@
 			}
 		},
 		"cypress": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-			"integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-13.0.0.tgz",
+			"integrity": "sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==",
 			"dev": true,
 			"requires": {
-				"@cypress/request": "^2.88.10",
+				"@cypress/request": "^3.0.0",
 				"@cypress/xvfb": "^1.2.4",
-				"@types/node": "^14.14.31",
+				"@types/node": "^16.18.39",
 				"@types/sinonjs__fake-timers": "8.1.1",
 				"@types/sizzle": "^2.3.2",
 				"arch": "^2.2.0",
@@ -21381,10 +21391,10 @@
 				"check-more-types": "^2.24.0",
 				"cli-cursor": "^3.1.0",
 				"cli-table3": "~0.6.1",
-				"commander": "^5.1.0",
+				"commander": "^6.2.1",
 				"common-tags": "^1.8.0",
 				"dayjs": "^1.10.4",
-				"debug": "^4.3.2",
+				"debug": "^4.3.4",
 				"enquirer": "^2.3.6",
 				"eventemitter2": "6.4.7",
 				"execa": "4.1.0",
@@ -21399,12 +21409,13 @@
 				"listr2": "^3.8.3",
 				"lodash": "^4.17.21",
 				"log-symbols": "^4.0.0",
-				"minimist": "^1.2.6",
+				"minimist": "^1.2.8",
 				"ospath": "^1.2.2",
 				"pretty-bytes": "^5.6.0",
+				"process": "^0.11.10",
 				"proxy-from-env": "1.0.0",
 				"request-progress": "^3.0.0",
-				"semver": "^7.3.2",
+				"semver": "^7.5.3",
 				"supports-color": "^8.1.1",
 				"tmp": "~0.2.1",
 				"untildify": "^4.0.0",
@@ -21475,9 +21486,9 @@
 					"dev": true
 				},
 				"semver": {
-					"version": "7.3.8",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+					"version": "7.5.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+					"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
@@ -25862,9 +25873,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
 		},
 		"mixin-deep": {
 			"version": "1.3.2",
@@ -27263,6 +27274,12 @@
 					}
 				}
 			}
+		},
+		"process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
 				"babel-eslint": "^10.0.3",
 				"babel-loader": "^8.0.6",
 				"cypress": "^13.0.0",
-				"cypress-iframe": "^1.0.1",
 				"cypress-mochawesome-reporter": "^3.5.1",
 				"eslint": "^6.3.0",
 				"husky": "^3.0.5",
@@ -3746,17 +3745,6 @@
 				"@types/responselike": "*"
 			}
 		},
-		"node_modules/@types/cypress": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@types/cypress/-/cypress-1.1.3.tgz",
-			"integrity": "sha512-OXe0Gw8LeCflkG1oPgFpyrYWJmEKqYncBsD/J0r17r0ETx/TnIGDNLwXt/pFYSYuYTpzcq1q3g62M9DrfsBL4g==",
-			"deprecated": "This is a stub types definition for cypress (https://cypress.io). cypress provides its own type definitions, so you don't need @types/cypress installed!",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"cypress": "*"
-			}
-		},
 		"node_modules/@types/eslint": {
 			"version": "8.4.7",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.7.tgz",
@@ -6042,15 +6030,6 @@
 			},
 			"engines": {
 				"node": "^16.0.0 || ^18.0.0 || >=20.0.0"
-			}
-		},
-		"node_modules/cypress-iframe": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/cypress-iframe/-/cypress-iframe-1.0.1.tgz",
-			"integrity": "sha512-Ne+xkZmWMhfq3x6wbfzK/SzsVTCrJru3R3cLXsoSAZyfUtJDamXyaIieHXeea3pQDXF4wE2w4iUuvCYHhoD31g==",
-			"dev": true,
-			"peerDependencies": {
-				"@types/cypress": "^1.1.0"
 			}
 		},
 		"node_modules/cypress-mochawesome-reporter": {
@@ -19585,16 +19564,6 @@
 				"@types/responselike": "*"
 			}
 		},
-		"@types/cypress": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@types/cypress/-/cypress-1.1.3.tgz",
-			"integrity": "sha512-OXe0Gw8LeCflkG1oPgFpyrYWJmEKqYncBsD/J0r17r0ETx/TnIGDNLwXt/pFYSYuYTpzcq1q3g62M9DrfsBL4g==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"cypress": "*"
-			}
-		},
 		"@types/eslint": {
 			"version": "8.4.7",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.7.tgz",
@@ -21504,13 +21473,6 @@
 					}
 				}
 			}
-		},
-		"cypress-iframe": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/cypress-iframe/-/cypress-iframe-1.0.1.tgz",
-			"integrity": "sha512-Ne+xkZmWMhfq3x6wbfzK/SzsVTCrJru3R3cLXsoSAZyfUtJDamXyaIieHXeea3pQDXF4wE2w4iUuvCYHhoD31g==",
-			"dev": true,
-			"requires": {}
 		},
 		"cypress-mochawesome-reporter": {
 			"version": "3.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@babel/core": "^7.6.0",
 				"@babel/preset-env": "^7.6.0",
 				"@babel/preset-react": "^7.0.0",
-				"@wordpress/env": "^5.7.0",
+				"@wordpress/env": "^8.6.0",
 				"@wordpress/eslint-plugin": "^3.0.0",
 				"@wordpress/prettier-config": "^1.1.1",
 				"babel-eslint": "^10.0.3",
@@ -1873,9 +1873,9 @@
 			}
 		},
 		"node_modules/@babel/register/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
 			"peer": true,
 			"bin": {
 				"semver": "bin/semver"
@@ -4156,9 +4156,9 @@
 			}
 		},
 		"node_modules/@wordpress/env": {
-			"version": "5.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-5.7.0.tgz",
-			"integrity": "sha512-9H5ZUhqRzdjghQgVMpxZDpx/W0Tf74D7mExFEQPGZdfoJUWNiHpgfbRK70IGKJk2kGit+9b90zuMIIA6PDahNw==",
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-8.6.0.tgz",
+			"integrity": "sha512-7iwJTXU0plBcwzCq6jTNRLrGV2ghYyZLB/4Jc9qld5w8zZ0Wu7DWmuQT6lmz67N1D2zPNgw2z3csKMcbxg77yQ==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.0.0",
@@ -5958,9 +5958,9 @@
 			}
 		},
 		"node_modules/cross-spawn/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
 			"bin": {
 				"semver": "bin/semver"
 			}
@@ -12728,9 +12728,9 @@
 			}
 		},
 		"node_modules/normalize-package-data/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver"
@@ -14549,9 +14549,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -18111,9 +18111,9 @@
 					}
 				},
 				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"version": "5.7.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+					"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
 					"peer": true
 				}
 			}
@@ -19966,9 +19966,9 @@
 			}
 		},
 		"@wordpress/env": {
-			"version": "5.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-5.7.0.tgz",
-			"integrity": "sha512-9H5ZUhqRzdjghQgVMpxZDpx/W0Tf74D7mExFEQPGZdfoJUWNiHpgfbRK70IGKJk2kGit+9b90zuMIIA6PDahNw==",
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-8.6.0.tgz",
+			"integrity": "sha512-7iwJTXU0plBcwzCq6jTNRLrGV2ghYyZLB/4Jc9qld5w8zZ0Wu7DWmuQT6lmz67N1D2zPNgw2z3csKMcbxg77yQ==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.0.0",
@@ -21345,9 +21345,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+					"version": "5.7.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+					"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
 				}
 			}
 		},
@@ -26570,9 +26570,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"version": "5.7.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+					"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
 					"dev": true
 				}
 			}
@@ -27934,9 +27934,9 @@
 			}
 		},
 		"semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
 		},
 		"semver-compare": {
 			"version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"@babel/core": "^7.6.0",
 		"@babel/preset-env": "^7.6.0",
 		"@babel/preset-react": "^7.0.0",
-		"@wordpress/env": "^5.7.0",
+		"@wordpress/env": "^8.6.0",
 		"@wordpress/eslint-plugin": "^3.0.0",
 		"@wordpress/prettier-config": "^1.1.1",
 		"babel-eslint": "^10.0.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	},
 	"homepage": "https://github.com/10up/autoshare#readme",
 	"devDependencies": {
-		"@10up/cypress-wp-utils": "^0.1.0",
+		"@10up/cypress-wp-utils": "^0.2.0",
 		"@10up/eslint-config": "^1.0.9",
 		"@babel/core": "^7.6.0",
 		"@babel/preset-env": "^7.6.0",
@@ -48,7 +48,7 @@
 		"@wordpress/prettier-config": "^1.1.1",
 		"babel-eslint": "^10.0.3",
 		"babel-loader": "^8.0.6",
-		"cypress": "^11.2.0",
+		"cypress": "^13.0.0",
 		"cypress-iframe": "^1.0.1",
 		"cypress-mochawesome-reporter": "^3.5.1",
 		"eslint": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
 		"babel-eslint": "^10.0.3",
 		"babel-loader": "^8.0.6",
 		"cypress": "^13.0.0",
-		"cypress-iframe": "^1.0.1",
 		"cypress-mochawesome-reporter": "^3.5.1",
 		"eslint": "^6.3.0",
 		"husky": "^3.0.5",

--- a/tests/bin/initialize.sh
+++ b/tests/bin/initialize.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-npm run env run tests-wordpress "chmod -c ugo+w /var/www/html"
-npm run env run tests-cli "wp rewrite structure '/%postname%/' --hard"
+wp-env run tests-wordpress chmod -c ugo+w /var/www/html
+wp-env run tests-cli wp rewrite structure '/%postname%/' --hard

--- a/tests/cypress/cypress.config.js
+++ b/tests/cypress/cypress.config.js
@@ -20,7 +20,6 @@ module.exports = defineConfig({
     runMode: 2,
     openMode: 0
   },
-  defaultCommandTimeout: 10000,
   reporter: 'mochawesome',
   reporterOptions: {
     mochaFile: "mochawesome-[name]",

--- a/tests/cypress/cypress.config.js
+++ b/tests/cypress/cypress.config.js
@@ -1,5 +1,6 @@
 const { defineConfig } = require('cypress');
-const { readConfig } = require('@wordpress/env/lib/config');
+const { loadConfig } = require( '@wordpress/env/lib/config' );
+const getCacheDirectory = require( '@wordpress/env/lib/config/get-cache-directory' );
 
 module.exports = defineConfig({
   chromeWebSecurity: false,
@@ -38,7 +39,8 @@ module.exports = defineConfig({
  * @returns config Updated Cypress Config object.
  */
 const setBaseUrl = async (on, config) => {
-  const wpEnvConfig = await readConfig('wp-env');
+  const cacheDirectory = await getCacheDirectory();
+  const wpEnvConfig = await loadConfig( cacheDirectory );
 
   if (wpEnvConfig) {
     const port = wpEnvConfig.env.tests.port || null;

--- a/tests/cypress/cypress.config.js
+++ b/tests/cypress/cypress.config.js
@@ -19,6 +19,7 @@ module.exports = defineConfig({
     runMode: 2,
     openMode: 0
   },
+  defaultCommandTimeout: 10000,
   reporter: 'mochawesome',
   reporterOptions: {
     mochaFile: "mochawesome-[name]",

--- a/tests/cypress/e2e/admin.test.js
+++ b/tests/cypress/e2e/admin.test.js
@@ -1,5 +1,5 @@
 describe('Admin can login and make sure plugin is activated', () => {
-	before(() => {
+	beforeEach(() => {
 		cy.login();
 		cy.clearPluginSettings();
 	});
@@ -14,6 +14,10 @@ describe('Admin can login and make sure plugin is activated', () => {
 });
 
 describe('Plugin settings page has the necessary fields', () => {
+	beforeEach(() => {
+		cy.login();
+	});
+
 	it('Can see all the fields on the settings page', () => {
 		cy.visit('/wp-admin/options-general.php?page=autoshare-for-twitter');
 		cy.get('input[name="autoshare-for-twitter[api_key]"]').should('be.visible');
@@ -22,6 +26,10 @@ describe('Plugin settings page has the necessary fields', () => {
 });
 
 describe('Configure the plugin', () => {
+	beforeEach(() => {
+		cy.login();
+	});
+
 	it('Configure the plugin settings and Twitter accounts', () => {
 		cy.visit('/wp-admin/options-general.php?page=autoshare-for-twitter');
 		cy.get('.large-text:nth-child(1) .large-text').clear().type( 'TEST_TWITTER_API_KEY' );

--- a/tests/cypress/e2e/block-editor.test.js
+++ b/tests/cypress/e2e/block-editor.test.js
@@ -179,7 +179,7 @@ describe('Test Autoshare for Twitter with Block Editor.', () => {
 			cy.get('.editor-post-publish-panel button[aria-label="Close panel"]').click();
 			cy.openDocumentSettingsPanel('Autotweet');
 			cy.get('.autoshare-for-twitter-editor-panel button.autoshare-for-twitter-tweet-now').click();
-			cy.get('.autoshare-for-twitter-editor-panel .autoshare-for-twitter-tweet-text textarea').clear().type(`Random Tweet ${getRandomText(6)}`);
+			cy.get('.autoshare-for-twitter-editor-panel .autoshare-for-twitter-tweet-text textarea').clear().type(`Random Tweet ${getRandomText(6)}`, {force: true});
 			cy.get('.autoshare-for-twitter-editor-panel button.autoshare-for-twitter-re-tweet').click();
 			cy.get('.autoshare-for-twitter-log a').contains('Tweeted on');
 		});
@@ -193,7 +193,7 @@ describe('Test Autoshare for Twitter with Block Editor.', () => {
 		// Open AutoTweet Panel and set custom tweet message.
 		cy.openDocumentSettingsPanel('Autotweet enabled');
 		cy.get('.autoshare-for-twitter-prepublish__override-row button').click();
-		cy.get('.autoshare-for-twitter-tweet-text textarea').clear().type(customTweetBody);
+		cy.get('.autoshare-for-twitter-tweet-text textarea').clear().type(customTweetBody,  {force: true});
 
 		// Save Draft
 		cy.get('.editor-post-save-draft').should('be.visible');

--- a/tests/cypress/e2e/block-editor.test.js
+++ b/tests/cypress/e2e/block-editor.test.js
@@ -15,6 +15,7 @@ describe('Test Autoshare for Twitter with Block Editor.', () => {
 	});
 
 	beforeEach(() => {
+		cy.login();
 		// Enable Autoshare on account.
 		cy.markAccountForAutoshare();
 	});

--- a/tests/cypress/e2e/classic-editor.test.js
+++ b/tests/cypress/e2e/classic-editor.test.js
@@ -36,7 +36,8 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 			cy.enableCheckbox('#autoshare-for-twitter-enable', defaultBehavior, false);
 
 			// publish
-			cy.get('#publish').should('be.visible').click({force: true});
+			cy.get('#publish').should('not.be.disabled');
+			cy.get('#publish').should('be.visible').click();
 
 			// Post-publish.
 			cy.get('#autoshare_for_twitter_metabox').should('be.visible');
@@ -50,7 +51,8 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 
 			// Check enable checkbox for auto-share.
 			cy.enableCheckbox('#autoshare-for-twitter-enable', defaultBehavior, true);
-			cy.get('#publish').should('be.visible').click({force: true});
+			cy.get('#publish').should('not.be.disabled');
+			cy.get('#publish').should('be.visible').click();
 
 			// Post-publish.
 			cy.get('#autoshare_for_twitter_metabox',).should('be.visible');
@@ -67,7 +69,8 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 
 			// Uncheck the checkbox and publish
 			cy.enableCheckbox('#autoshare-for-twitter-enable', defaultBehavior, false);
-			cy.get('#publish').should('be.visible').click({force: true});
+			cy.get('#publish').should('not.be.disabled');
+			cy.get('#publish').should('be.visible').click();
 
 			// Post-publish.
 			cy.get('#autoshare_for_twitter_metabox').should('be.visible');
@@ -84,7 +87,8 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 			
 			// Check the checkbox and publish
 			cy.enableCheckbox('#autoshare-for-twitter-enable', defaultBehavior, true);
-			cy.get('#publish').should('be.visible').click({force: true});
+			cy.get('#publish').should('not.be.disabled');
+			cy.get('#publish').should('be.visible').click();
 
 			// Post-publish.
 			cy.get('#autoshare_for_twitter_metabox').should('be.visible');
@@ -99,8 +103,9 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 			cy.enableCheckbox('#autoshare-for-twitter-enable', defaultBehavior, true);
 			cy.enableTweetAccount('input.autoshare-for-twitter-account-checkbox', false);
 
-			// publish
-			cy.get('#publish').should('be.visible').click({force: true});
+			// publish.
+			cy.get('#publish').should('not.be.disabled');
+			cy.get('#publish').should('be.visible').click();
 
 			// Post-publish.
 			cy.get('#autoshare_for_twitter_metabox').should('be.visible');
@@ -119,7 +124,8 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 			cy.enableTweetAccount('input.autoshare-for-twitter-account-checkbox', true);
 
 			// publish
-			cy.get('#publish').should('be.visible').click({force: true});
+			cy.get('#publish').should('not.be.disabled');
+			cy.get('#publish').should('be.visible').click();
 
 			// Post-publish.
 			cy.get('#autoshare_for_twitter_metabox',).should('be.visible');
@@ -135,7 +141,8 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 	
 			// Uncheck the checkbox and publish
 			cy.enableCheckbox('#autoshare-for-twitter-enable', defaultBehavior, false);
-			cy.get('#publish').should('be.visible').click({force: true});
+			cy.get('#publish').should('not.be.disabled');
+			cy.get('#publish').should('be.visible').click();
 	
 			// Post-publish.
 			cy.get('#autoshare_for_twitter_metabox').should('be.visible');
@@ -167,7 +174,8 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 		cy.get('textarea#autoshare-for-twitter-text').should('have.value', customTweetBody);
 
 		// publish
-		cy.get('#publish').should('be.visible').click({force: true});
+		cy.get('#publish').should('not.be.disabled');
+		cy.get('#publish').should('be.visible').click();
 
 		// Post-publish.
 		cy.get('#autoshare_for_twitter_metabox',).should('be.visible');

--- a/tests/cypress/e2e/classic-editor.test.js
+++ b/tests/cypress/e2e/classic-editor.test.js
@@ -9,6 +9,7 @@ describe('Test Autoshare for Twitter with Classic Editor.', () => {
 	});
 
 	beforeEach(() => {
+		cy.login();
 		// Enable Autoshare on account.
 		cy.markAccountForAutoshare();
 	});

--- a/tests/cypress/e2e/disconnect.test.js
+++ b/tests/cypress/e2e/disconnect.test.js
@@ -4,6 +4,10 @@ describe('Admin can disconnect connected Twitter accounts', () => {
         cy.configurePlugin();
 	});
 
+	beforeEach(() => {
+		cy.login();
+	});
+
 	it('Admin can disconnect connected Twitter accounts', () => {
 		cy.visit('/wp-admin/options-general.php?page=autoshare-for-twitter');
 		cy.get('.twitter_accounts #the-list tr').should('be.visible').should('have.length', 2);

--- a/tests/cypress/e2e/mutli-accounts.test.js
+++ b/tests/cypress/e2e/mutli-accounts.test.js
@@ -4,6 +4,10 @@ describe('Twitter accounts should visible in Autotweet Panel and should respect 
 		cy.configurePlugin();
 	});
 
+	beforeEach(() => {
+		cy.login();
+	});
+
 	it('Can see Twitter accounts in Block editor', () => {
 		//Block editor.
 		cy.enableEditor('block');

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -56,7 +56,7 @@ Cypress.Commands.add('openPrePublishPanel', () => {
 
 Cypress.Commands.add(
 	'enableCheckbox',
-	(checkboxSelector, defaultBehavior, check = true) => {
+	(checkboxSelector, defaultBehavior, check) => {
 		// Check/Uncheck enable checkbox for auto-share.
 		cy.get(checkboxSelector).should('exist');
 		if (true === defaultBehavior) {
@@ -65,19 +65,28 @@ Cypress.Commands.add(
 			cy.get(checkboxSelector).first().should('not.be.checked');
 		}
 
-		cy.intercept('**/autoshare/v1/post-autoshare-for-twitter-meta/*').as(
-			'enableCheckbox'
-		);
+		if (defaultBehavior === check) {
+			return;
+		}
+
 		if (true === check) {
 			cy.get(checkboxSelector).first().check({ force: true });
-			if (defaultBehavior !== check) {
-				cy.wait('@enableCheckbox');
+			if (checkboxSelector === '#autoshare-for-twitter-enable') {
+				cy.get('#publish').should('not.be.disabled');
+			} else {
+				cy.get('button.editor-post-publish-button').should(
+					'not.be.disabled'
+				);
 			}
 			cy.get(checkboxSelector).first().should('be.checked');
 		} else {
 			cy.get(checkboxSelector).first().uncheck({ force: true });
-			if (defaultBehavior !== check) {
-				cy.wait('@enableCheckbox');
+			if (checkboxSelector === '#autoshare-for-twitter-enable') {
+				cy.get('#publish').should('not.be.disabled');
+			} else {
+				cy.get('button.editor-post-publish-button').should(
+					'not.be.disabled'
+				);
 			}
 			cy.get(checkboxSelector).first().should('not.be.checked');
 		}
@@ -126,17 +135,26 @@ Cypress.Commands.add('enableTweetAccount', (selector, check = true) => {
 	// Check/Uncheck enable checkbox for auto-share.
 	const checkbox = cy.get(selector).first();
 	checkbox.should('exist');
-	cy.intercept('**/autoshare/v1/post-autoshare-for-twitter-meta/*').as(
-		'enableTweetAccount'
-	);
 	if (true === check) {
 		checkbox.check({ force: true });
-		cy.wait('@enableTweetAccount');
-		checkbox.should('be.checked');
+		if (selector === 'input.autoshare-for-twitter-account-checkbox') {
+			cy.get('#publish').should('not.be.disabled');
+		} else {
+			cy.get('button.editor-post-publish-button').should(
+				'not.be.disabled'
+			);
+		}
+		cy.get(selector).first().should('be.checked');
 	} else {
 		checkbox.uncheck({ force: true });
-		cy.wait('@enableTweetAccount');
-		checkbox.should('not.be.checked');
+		if (selector === 'input.autoshare-for-twitter-account-checkbox') {
+			cy.get('#publish').should('not.be.disabled');
+		} else {
+			cy.get('button.editor-post-publish-button').should(
+				'not.be.disabled'
+			);
+		}
+		cy.get(selector).first().should('not.be.checked');
 	}
 });
 
@@ -183,6 +201,6 @@ Cypress.Commands.add('publishPost', () => {
 		}
 	});
 
-	cy.get('[aria-disabled="false"].editor-post-publish-button').click();
+	cy.get('button[aria-disabled="false"].editor-post-publish-button').click();
 	cy.wait('@publishPost');
 });

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -71,22 +71,24 @@ Cypress.Commands.add(
 
 		if (true === check) {
 			cy.get(checkboxSelector).first().check({ force: true });
+			cy.wait(1000);
 			if (checkboxSelector === '#autoshare-for-twitter-enable') {
 				cy.get('#publish').should('not.be.disabled');
 			} else {
-				cy.get('button.editor-post-publish-button').should(
-					'not.be.disabled'
-				);
+				cy.get(
+					'.editor-post-publish-panel__header-publish-button button.editor-post-publish-button'
+				).should('not.be.disabled');
 			}
 			cy.get(checkboxSelector).first().should('be.checked');
 		} else {
 			cy.get(checkboxSelector).first().uncheck({ force: true });
+			cy.wait(1000);
 			if (checkboxSelector === '#autoshare-for-twitter-enable') {
 				cy.get('#publish').should('not.be.disabled');
 			} else {
-				cy.get('button.editor-post-publish-button').should(
-					'not.be.disabled'
-				);
+				cy.get(
+					'.editor-post-publish-panel__header-publish-button button.editor-post-publish-button'
+				).should('not.be.disabled');
 			}
 			cy.get(checkboxSelector).first().should('not.be.checked');
 		}
@@ -137,22 +139,24 @@ Cypress.Commands.add('enableTweetAccount', (selector, check = true) => {
 	checkbox.should('exist');
 	if (true === check) {
 		checkbox.check({ force: true });
+		cy.wait(1000);
 		if (selector === 'input.autoshare-for-twitter-account-checkbox') {
 			cy.get('#publish').should('not.be.disabled');
 		} else {
-			cy.get('button.editor-post-publish-button').should(
-				'not.be.disabled'
-			);
+			cy.get(
+				'.editor-post-publish-panel__header-publish-button button.editor-post-publish-button'
+			).should('not.be.disabled');
 		}
 		cy.get(selector).first().should('be.checked');
 	} else {
 		checkbox.uncheck({ force: true });
+		cy.wait(1000);
 		if (selector === 'input.autoshare-for-twitter-account-checkbox') {
 			cy.get('#publish').should('not.be.disabled');
 		} else {
-			cy.get('button.editor-post-publish-button').should(
-				'not.be.disabled'
-			);
+			cy.get(
+				'.editor-post-publish-panel__header-publish-button button.editor-post-publish-button'
+			).should('not.be.disabled');
 		}
 		cy.get(selector).first().should('not.be.checked');
 	}

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -186,25 +186,3 @@ Cypress.Commands.add('publishPost', () => {
 	cy.get('[aria-disabled="false"].editor-post-publish-button').click();
 	cy.wait('@publishPost');
 });
-
-Cypress.Commands.add('getBlockEditor', () => {
-	cy.get('.edit-post-visual-editor').should('be.visible');
-	return cy
-		.get('body')
-		.then(($body) => {
-			if ($body.find('iframe[name="editor-canvas"]').length) {
-				return cy.iframe('iframe[name="editor-canvas"]');
-			}
-			return $body;
-		})
-		.then(cy.wrap);
-});
-
-Cypress.Commands.add('closeWelcomeGuide', () => {
-	cy.window().then((win) => {
-		const { wp } = win;
-		if (wp.data.select('core/edit-post').isFeatureActive('welcomeGuide')) {
-			wp.data.dispatch('core/edit-post').toggleFeature('welcomeGuide');
-		}
-	});
-});

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -23,9 +23,9 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
-import { getRandomText } from "../support/functions";
+import { getRandomText } from '../support/functions';
 
-Cypress.Commands.add( 'startCreatePost', () => {
+Cypress.Commands.add('startCreatePost', () => {
 	cy.visit('/wp-admin/post-new.php');
 	const titleInput = 'h1.editor-post-title__input, #post-title-0';
 
@@ -39,51 +39,57 @@ Cypress.Commands.add( 'startCreatePost', () => {
 		.type(`Random Post Title ${getRandomText(6)}`);
 });
 
-
-Cypress.Commands.add( 'classicStartCreatePost', () => {
+Cypress.Commands.add('classicStartCreatePost', () => {
 	cy.visit('/wp-admin/post-new.php');
 	let postTitle = getRandomText(8);
-	cy.get('input[name="post_title"]').type('Random Post Title' + postTitle );
+	cy.get('input[name="post_title"]').type('Random Post Title' + postTitle);
 });
 
-Cypress.Commands.add( 'openPrePublishPanel', () => {
+Cypress.Commands.add('openPrePublishPanel', () => {
 	// Open pre-publish Panel.
 	cy.get('.editor-post-publish-panel__toggle').should('be.visible');
 	cy.get('.editor-post-publish-panel__toggle').click();
 	cy.wait(500); // prevent clicking on category assign suggestion panel. ToDo: find more proper way to handle this.
 	cy.get('.autoshare-for-twitter-pre-publish-panel').should('exist');
-	cy.get('.autoshare-for-twitter-pre-publish-panel').click();	
+	cy.get('.autoshare-for-twitter-pre-publish-panel').click();
 });
 
-Cypress.Commands.add( 'enableCheckbox', ( checkboxSelector, defaultBehavior, check = true ) => {
-	// Check/Uncheck enable checkbox for auto-share.
-	cy.get(checkboxSelector).should('exist');
-	if (true === defaultBehavior) {
-		cy.get(checkboxSelector).first().should('be.checked');
-	} else {
-		cy.get(checkboxSelector).first().should('not.be.checked');
-	}
-
-	cy.intercept('**/autoshare/v1/post-autoshare-for-twitter-meta/*').as('enableCheckbox');
-	if (true === check) {
-		cy.get(checkboxSelector).first().check({force: true});
-		if(defaultBehavior !== check){
-			cy.wait('@enableCheckbox');
+Cypress.Commands.add(
+	'enableCheckbox',
+	(checkboxSelector, defaultBehavior, check = true) => {
+		// Check/Uncheck enable checkbox for auto-share.
+		cy.get(checkboxSelector).should('exist');
+		if (true === defaultBehavior) {
+			cy.get(checkboxSelector).first().should('be.checked');
+		} else {
+			cy.get(checkboxSelector).first().should('not.be.checked');
 		}
-		cy.get(checkboxSelector).first().should('be.checked');
-	} else {
-		cy.get(checkboxSelector).first().uncheck({force: true});
-		if(defaultBehavior !== check){
-			cy.wait('@enableCheckbox');
-		}
-		cy.get(checkboxSelector).first().should('not.be.checked');
-	}
-});
 
-Cypress.Commands.add( 'openAutoTweetPanel', ( inPrePublish = false ) => {
+		cy.intercept('**/autoshare/v1/post-autoshare-for-twitter-meta/*').as(
+			'enableCheckbox'
+		);
+		if (true === check) {
+			cy.get(checkboxSelector).first().check({ force: true });
+			if (defaultBehavior !== check) {
+				cy.wait('@enableCheckbox');
+			}
+			cy.get(checkboxSelector).first().should('be.checked');
+		} else {
+			cy.get(checkboxSelector).first().uncheck({ force: true });
+			if (defaultBehavior !== check) {
+				cy.wait('@enableCheckbox');
+			}
+			cy.get(checkboxSelector).first().should('not.be.checked');
+		}
+	}
+);
+
+Cypress.Commands.add('openAutoTweetPanel', (inPrePublish = false) => {
 	// Open Autotweet Panel.
-	let panelSelector = inPrePublish ? '.autoshare-for-twitter-pre-publish-panel' : '.autoshare-for-twitter-editor-panel';
-	cy.get(`${panelSelector} button.components-button`).then($button => {
+	let panelSelector = inPrePublish
+		? '.autoshare-for-twitter-pre-publish-panel'
+		: '.autoshare-for-twitter-editor-panel';
+	cy.get(`${panelSelector} button.components-button`).then(($button) => {
 		const $panel = $button.parents('.components-panel__body');
 		if (!$panel.hasClass('is-opened')) {
 			cy.wrap($button)
@@ -94,11 +100,13 @@ Cypress.Commands.add( 'openAutoTweetPanel', ( inPrePublish = false ) => {
 	});
 });
 
-Cypress.Commands.add( 'markAccountForAutoshare', ( enable = true ) => {
+Cypress.Commands.add('markAccountForAutoshare', (enable = true) => {
 	cy.visit('/wp-admin/options-general.php?page=autoshare-for-twitter');
 	cy.get('.twitter_accounts #the-list tr').should('be.visible');
-	const checkbox = cy.get('input[name="autoshare-for-twitter[autoshare_accounts][]"]').first();
-	if ( enable ) {
+	const checkbox = cy
+		.get('input[name="autoshare-for-twitter[autoshare_accounts][]"]')
+		.first();
+	if (enable) {
 		checkbox.should('exist').check();
 	} else {
 		checkbox.should('exist').uncheck();
@@ -107,66 +115,76 @@ Cypress.Commands.add( 'markAccountForAutoshare', ( enable = true ) => {
 	cy.get('.notice.notice-success').should('be.visible');
 });
 
-Cypress.Commands.add( 'enableEditor', ( editor = 'block' ) => {
+Cypress.Commands.add('enableEditor', (editor = 'block') => {
 	cy.visit('/wp-admin/options-writing.php#classic-editor-options');
-		cy.get(`#classic-editor-${editor}`).click();
-		cy.get('#classic-editor-disallow').click();
-		cy.get('#submit').click();
+	cy.get(`#classic-editor-${editor}`).click();
+	cy.get('#classic-editor-disallow').click();
+	cy.get('#submit').click();
 });
 
-Cypress.Commands.add( 'enableTweetAccount', ( selector, check = true ) => {
+Cypress.Commands.add('enableTweetAccount', (selector, check = true) => {
 	// Check/Uncheck enable checkbox for auto-share.
 	const checkbox = cy.get(selector).first();
 	checkbox.should('exist');
-	cy.intercept('**/autoshare/v1/post-autoshare-for-twitter-meta/*').as('enableTweetAccount');
+	cy.intercept('**/autoshare/v1/post-autoshare-for-twitter-meta/*').as(
+		'enableTweetAccount'
+	);
 	if (true === check) {
-		checkbox.check({force: true});
+		checkbox.check({ force: true });
 		cy.wait('@enableTweetAccount');
 		checkbox.should('be.checked');
 	} else {
-		checkbox.uncheck({force: true});
+		checkbox.uncheck({ force: true });
 		cy.wait('@enableTweetAccount');
 		checkbox.should('not.be.checked');
 	}
 });
 
-Cypress.Commands.add( 'configurePlugin', () => {
+Cypress.Commands.add('configurePlugin', () => {
 	cy.visit('/wp-admin/options-general.php?page=autoshare-for-twitter');
-	cy.get('body').then($body => {
+	cy.get('body').then(($body) => {
 		const apiKeySelector = '.credentials-setup.connected';
-        if ($body.find(apiKeySelector).length < 1) {
-            cy.get('.large-text:nth-child(1) .large-text').clear().type( 'TEST_TWITTER_API_KEY' );
-			cy.get('.large-text:nth-child(2) .large-text').clear().type( 'TEST_TWITTER_API_SECRET' );
+		if ($body.find(apiKeySelector).length < 1) {
+			cy.get('.large-text:nth-child(1) .large-text')
+				.clear()
+				.type('TEST_TWITTER_API_KEY');
+			cy.get('.large-text:nth-child(2) .large-text')
+				.clear()
+				.type('TEST_TWITTER_API_SECRET');
 			cy.get('#submit').click();
-        }
-    });
+		}
+	});
 
-	cy.get('body').then($body => {
+	cy.get('body').then(($body) => {
 		const accountSelector = '.twitter_accounts #the-list tr';
-        if ($body.find(accountSelector).length < 2) {
+		if ($body.find(accountSelector).length < 2) {
 			cy.connectAccounts();
-        }
-    });
+		}
+	});
 });
 
-Cypress.Commands.add( 'clearPluginSettings', () => {
-	cy.wpCli(`option delete autoshare-for-twitter autoshare_for_twitter_accounts`);
+Cypress.Commands.add('clearPluginSettings', () => {
+	cy.exec(
+		`npm run env run tests-cli wp option delete autoshare-for-twitter autoshare_for_twitter_accounts`
+	);
 });
 
-Cypress.Commands.add( 'connectAccounts', () => {
-	cy.wpCli(`option update autoshare_for_twitter_accounts '{"TEST_ACCOUNT_ID":{"id":"TEST_ACCOUNT_ID","name":"Test Twitter User","username":"testtwitteruser","profile_image_url":"https://placehold.co\/48x48?text=T1","oauth_token":"TEST_OUTH_TOKEN","oauth_token_secret":"TEST_OUTH_TOKEN_SECRET"},"TEST_ACCOUNT_ID2":{"id":"TEST_ACCOUNT_ID2","name":"Test Twitter User 2","username":"testtwitteruser2","profile_image_url":"https://placehold.co\/48x48?text=T2","oauth_token":"TEST_OUTH_TOKEN2","oauth_token_secret":"TEST_OUTH_TOKEN_SECRET2"}}' --format=json`);
+Cypress.Commands.add('connectAccounts', () => {
+	cy.exec(
+		`npm --silent run env run tests-cli wp option update autoshare_for_twitter_accounts '{"TEST_ACCOUNT_ID":{"id":"TEST_ACCOUNT_ID","name":"Test Twitter User","username":"testtwitteruser","profile_image_url":"https://placehold.co\/48x48?text=T1","oauth_token":"TEST_OUTH_TOKEN","oauth_token_secret":"TEST_OUTH_TOKEN_SECRET"},"TEST_ACCOUNT_ID2":{"id":"TEST_ACCOUNT_ID2","name":"Test Twitter User 2","username":"testtwitteruser2","profile_image_url":"https://placehold.co\/48x48?text=T2","oauth_token":"TEST_OUTH_TOKEN2","oauth_token_secret":"TEST_OUTH_TOKEN_SECRET2"}}' -- --format=json`
+	);
 });
 
-Cypress.Commands.add( 'publishPost', () => {
-    cy.intercept({ method: 'POST' }, req => {
-      const body = req.body;
-      if (body.status === 'publish') {
-        req.alias = 'publishPost';
-      }
-    });
+Cypress.Commands.add('publishPost', () => {
+	cy.intercept({ method: 'POST' }, (req) => {
+		const body = req.body;
+		if (body.status === 'publish') {
+			req.alias = 'publishPost';
+		}
+	});
 
 	cy.get('[aria-disabled="false"].editor-post-publish-button').click();
-    cy.wait('@publishPost');
+	cy.wait('@publishPost');
 });
 
 Cypress.Commands.add('getBlockEditor', () => {
@@ -185,14 +203,8 @@ Cypress.Commands.add('getBlockEditor', () => {
 Cypress.Commands.add('closeWelcomeGuide', () => {
 	cy.window().then((win) => {
 		const { wp } = win;
-		if (
-			wp.data
-				.select('core/edit-post')
-				.isFeatureActive('welcomeGuide')
-		) {
-			wp.data
-				.dispatch('core/edit-post')
-				.toggleFeature('welcomeGuide');
+		if (wp.data.select('core/edit-post').isFeatureActive('welcomeGuide')) {
+			wp.data.dispatch('core/edit-post').toggleFeature('welcomeGuide');
 		}
 	});
 });

--- a/tests/cypress/support/e2e.js
+++ b/tests/cypress/support/e2e.js
@@ -1,3 +1,2 @@
 import '@10up/cypress-wp-utils';
-import 'cypress-iframe';
 import './commands';

--- a/tests/cypress/support/e2e.js
+++ b/tests/cypress/support/e2e.js
@@ -1,9 +1,3 @@
 import '@10up/cypress-wp-utils';
 import 'cypress-iframe';
 import './commands';
-
-beforeEach(() => {
-	Cypress.Cookies.defaults({
-		preserve: /^wordpress.*?/,
-	});
-});


### PR DESCRIPTION
### Description of the Change
This PR upgrades the Cypress, Cypress utils lib, and @wordpress/env. Updates needed files as part of the upgrade.

- Bump `Cypress` version from 11.2.0 to 13.0.0
- Bump `@10up/cypress-wp-utils` version from 0.1.0 to 0.2.0
- Bump `@wordpress/env` version from 5.7.0 to 8.6.0

Closes #280 

### How to test the Change
Make sure PR `PASS` E2E tests check OR verify E2E tests locally.

### Changelog Entry
> Changed - Bump `Cypress` version from 11.2.0 to 13.0.0
> Changed - Bump `@10up/cypress-wp-utils` version from 0.1.0 to 0.2.0
> Changed - Bump `@wordpress/env` version from 5.7.0 to 8.6.0

### Credits
Props @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
