### PR TITLE
Fix URL length calculations for long Permalinks

### DIFF
--- a/assets/js/admin-autoshare-for-twitter-classic-editor.js
+++ b/assets/js/admin-autoshare-for-twitter-classic-editor.js
@@ -125,15 +125,41 @@
 	}
 
 	/**
-	 * Updates the counter
+	 * Calculates the permalink length
 	 */
-	function updateRemainingField() {
+	function getPermalinkLength() {
 		let permalinkLength = 0;
 		if ( $('#sample-permalink').length ) {
-			permalinkLength = $('#sample-permalink').text().length
+			if (adminAutoshareForTwitter.twitterURLLength) {
+				// according to this page https://developer.twitter.com/en/docs/counting-characters, all URLs are transformed to a uniform length
+				permalinkLength = adminAutoshareForTwitter.twitterURLLength;
+			} else {
+				// The #sample-permalink > a tag seems like the only convenient place to get the correct path for the post,
+				// without doing an AJAX call. We're using this technique to isolate the path (remove the <span>):
+				// https://stackoverflow.com/a/74517817
+				let slug = $("#editable-post-name-full").text();
+
+				// get the hypothetical path
+				let aTagContents = $("#sample-permalink > a")[0].innerHTML;
+				let workingDiv = document.createElement("span");
+				workingDiv.innerHTML = aTagContents;
+				let fakeSlugSpan = workingDiv.querySelector('span');
+				workingDiv.removeChild(fakeSlugSpan);
+				let permalinkPrefix = workingDiv.innerText;
+				let permalink = permalinkPrefix + slug + '/';
+				permalinkLength = permalink.length;
+			}
 		}
 		// +5 because of the space between body and URL and the ellipsis.
 		permalinkLength += 5;
+		return permalinkLength;
+	}
+
+	/**
+	 * Updates the counter
+	 */
+	function updateRemainingField() {
+		const permalinkLength = getPermalinkLength();
 
 		var count = $tweetText.val().length + permalinkLength;
 		$tweetText.attr('maxlength', limit - permalinkLength);

--- a/assets/js/admin-autoshare-for-twitter-classic-editor.js
+++ b/assets/js/admin-autoshare-for-twitter-classic-editor.js
@@ -142,25 +142,20 @@
 	function getPermalinkLength() {
 		let permalinkLength = 0;
 		if ($('#sample-permalink').length) {
-			if (adminAutoshareForTwitter.twitterURLLength) {
-				// according to this page https://developer.twitter.com/en/docs/counting-characters, all URLs are transformed to a uniform length
+			if (
+				! adminAutoshareForTwitter.isLocalSite &&
+				! isNaN( adminAutoshareForTwitter.twitterURLLength )
+			) {
+				// According to this page https://developer.twitter.com/en/docs/counting-characters, all URLs are transformed to a uniform length
 				permalinkLength = Number(
 					adminAutoshareForTwitter.twitterURLLength
 				);
 			} else {
-				// The #sample-permalink > a tag seems like the only convenient place to get the correct path for the post,
-				// without doing an AJAX call. We're using this technique to isolate the path (remove the <span>):
-				// https://stackoverflow.com/a/74517817
-				let slug = jQuery('#editable-post-name-full').text();
-
-				// get the hypothetical path
-				let aTagContents = jQuery('#sample-permalink > a')[0].innerHTML;
-				let workingDiv = document.createElement('span');
-				workingDiv.innerHTML = aTagContents;
-				let fakeSlugSpan = workingDiv.querySelector('span');
-				workingDiv.removeChild(fakeSlugSpan);
-				let permalinkPrefix = workingDiv.innerText;
-				let permalink = permalinkPrefix + slug + '/';
+				// Calculate the permalink length.
+				const slug = jQuery('#editable-post-name-full').text();
+				const aTagContents = jQuery('#sample-permalink > a')[0].innerHTML;
+				const permalinkPrefix = 'string' === typeof aTagContents ? aTagContents.split('<span')[0] : '';
+				const permalink = permalinkPrefix + slug + '/';
 				permalinkLength = permalink.length;
 			}
 		}

--- a/assets/js/admin-autoshare-for-twitter-classic-editor.js
+++ b/assets/js/admin-autoshare-for-twitter-classic-editor.js
@@ -3,7 +3,7 @@
  *
  * @todo soooo much dependency :facepalm:
  */
-(function($) {
+(function ($) {
 	'use strict';
 
 	var $tweetPost = $('#autoshare-for-twitter-enable'),
@@ -12,10 +12,16 @@
 		$editLink = $('#autoshare-for-twitter-edit'),
 		$editBody = $('#autoshare-for-twitter-override-body'),
 		$hideLink = $('.cancel-tweet-text'),
-		$allowTweetImage = $('#autoshare-for-twitter-tweet-allow-image'),		
-		errorMessageContainer = document.getElementById('autoshare-for-twitter-error-message'),
-		counterWrap = document.getElementById('autoshare-for-twitter-counter-wrap'),
-		allowTweetImageWrap = $('.autoshare-for-twitter-tweet-allow-image-wrap'),
+		$allowTweetImage = $('#autoshare-for-twitter-tweet-allow-image'),
+		errorMessageContainer = document.getElementById(
+			'autoshare-for-twitter-error-message'
+		),
+		counterWrap = document.getElementById(
+			'autoshare-for-twitter-counter-wrap'
+		),
+		allowTweetImageWrap = $(
+			'.autoshare-for-twitter-tweet-allow-image-wrap'
+		),
 		limit = 280;
 	const { __, sprintf } = wp.i18n;
 
@@ -29,23 +35,26 @@
 	$tweetText.change(handleRequest);
 	$tweetPost.change(toggleVisibility);
 	$allowTweetImage.change(handleRequest);
-	$editLink.on('click', function() {
+	$editLink.on('click', function () {
 		$editBody.slideToggle();
 		updateRemainingField();
 		$(this).hide();
 	});
-	$tweetText.on('keyup', function() {
+	$tweetText.on('keyup', function () {
 		updateRemainingField();
 	});
-	$hideLink.on('click', function(e) {
+	$hideLink.on('click', function (e) {
 		e.preventDefault();
 		$('#autoshare-for-twitter-override-body').slideToggle();
 		$editLink.show();
 	});
-	$('input.autoshare-for-twitter-account-checkbox').on('change', handleRequest);
+	$('input.autoshare-for-twitter-account-checkbox').on(
+		'change',
+		handleRequest
+	);
 
 	// Runs on page load to auto-enable posts to be tweeted
-	window.onload = function(event) {
+	window.onload = function (event) {
 		if ('' === adminAutoshareForTwitter.currentStatus) {
 			handleRequest(event, true);
 		}
@@ -77,12 +86,15 @@
 	function handleRequest(event, status = $tweetPost.prop('checked')) {
 		let data = {};
 		let enabledAccounts = [];
-		$('input.autoshare-for-twitter-account-checkbox:checked').each(function() {
-			enabledAccounts.push($(this).val());
-		});
+		$('input.autoshare-for-twitter-account-checkbox:checked').each(
+			function () {
+				enabledAccounts.push($(this).val());
+			}
+		);
 		data[adminAutoshareForTwitter.enableAutoshareKey] = status;
 		data[adminAutoshareForTwitter.tweetBodyKey] = $tweetText.val();
-		data[adminAutoshareForTwitter.allowTweetImageKey] = $allowTweetImage.prop('checked');
+		data[adminAutoshareForTwitter.allowTweetImageKey] =
+			$allowTweetImage.prop('checked');
 		data[adminAutoshareForTwitter.tweetAccountsKey] = enabledAccounts;
 		$('#publish').prop('disabled', true);
 
@@ -92,14 +104,14 @@
 			method: 'POST',
 			parse: false, // We'll check the response for errors.
 		})
-			.then(function(response) {
+			.then(function (response) {
 				if (!response.ok) {
 					throw response;
 				}
 
 				return response.json();
 			})
-			.then(function(data) {
+			.then(function (data) {
 				errorMessageContainer.innerText = '';
 
 				$icon.removeClass('pending');
@@ -129,19 +141,21 @@
 	 */
 	function getPermalinkLength() {
 		let permalinkLength = 0;
-		if ( $('#sample-permalink').length ) {
+		if ($('#sample-permalink').length) {
 			if (adminAutoshareForTwitter.twitterURLLength) {
 				// according to this page https://developer.twitter.com/en/docs/counting-characters, all URLs are transformed to a uniform length
-				permalinkLength = adminAutoshareForTwitter.twitterURLLength;
+				permalinkLength = Number(
+					adminAutoshareForTwitter.twitterURLLength
+				);
 			} else {
 				// The #sample-permalink > a tag seems like the only convenient place to get the correct path for the post,
 				// without doing an AJAX call. We're using this technique to isolate the path (remove the <span>):
 				// https://stackoverflow.com/a/74517817
-				let slug = $("#editable-post-name-full").text();
+				let slug = jQuery('#editable-post-name-full').text();
 
 				// get the hypothetical path
-				let aTagContents = $("#sample-permalink > a")[0].innerHTML;
-				let workingDiv = document.createElement("span");
+				let aTagContents = jQuery('#sample-permalink > a')[0].innerHTML;
+				let workingDiv = document.createElement('span');
 				workingDiv.innerHTML = aTagContents;
 				let fakeSlugSpan = workingDiv.querySelector('span');
 				workingDiv.removeChild(fakeSlugSpan);
@@ -171,12 +185,19 @@
 			counterWrap.classList.remove('near-limit');
 			counterWrap.classList.add('over-limit');
 			/* translators: %d is tweet message character count */
-			$(counterWrap).text( sprintf( __( '%d - Too Long!', 'autoshare-for-twitter' ), count ) );
+			$(counterWrap).text(
+				sprintf(__('%d - Too Long!', 'autoshare-for-twitter'), count)
+			);
 		} else if (240 <= count) {
 			counterWrap.classList.remove('over-limit');
 			counterWrap.classList.add('near-limit');
 			/* translators: %d is tweet message character count */
-			$(counterWrap).text( sprintf( __( '%d - Getting Long!', 'autoshare-for-twitter' ), count ) );
+			$(counterWrap).text(
+				sprintf(
+					__('%d - Getting Long!', 'autoshare-for-twitter'),
+					count
+				)
+			);
 		} else {
 			counterWrap.classList.remove('near-limit');
 			counterWrap.classList.remove('over-limit');
@@ -184,7 +205,7 @@
 	}
 
 	// Update the counter when the permalink is changed.
-	$( '#titlediv' ).on( 'focus', '.edit-slug', function() {
+	$('#titlediv').on('focus', '.edit-slug', function () {
 		updateRemainingField();
 	});
 
@@ -198,21 +219,25 @@
 	}
 
 	// Show/Hide "Use featured image in Tweet" checkbox.
-	if ( allowTweetImageWrap && wp.media.featuredImage ) {
+	if (allowTweetImageWrap && wp.media.featuredImage) {
 		toggleAllowImageVisibility();
 		// Listen event for add/remove featured image.
-		wp.media.featuredImage.frame().on( 'select', toggleAllowImageVisibility );
-		$('#postimagediv').on( 'click', '#remove-post-thumbnail', toggleAllowImageVisibility );
+		wp.media.featuredImage.frame().on('select', toggleAllowImageVisibility);
+		$('#postimagediv').on(
+			'click',
+			'#remove-post-thumbnail',
+			toggleAllowImageVisibility
+		);
 	}
 
 	/**
 	 * Show/Hide accounts and visibility options.
 	 */
-	function toggleVisibility( event ) {
-		toggleAllowImageVisibility( event );
+	function toggleVisibility(event) {
+		toggleAllowImageVisibility(event);
 		const autoshareEnabled = $tweetPost.prop('checked');
 		const accountsWrap = $('.autoshare-for-twitter-accounts-wrapper');
-		if ( autoshareEnabled ) {
+		if (autoshareEnabled) {
 			accountsWrap.show();
 		} else {
 			accountsWrap.hide();
@@ -222,17 +247,22 @@
 	/**
 	 * Show/Hide "Use featured image in Tweet" checkbox.
 	 */
-	function toggleAllowImageVisibility( event ) {
+	function toggleAllowImageVisibility(event) {
 		let hasMedia = wp.media.featuredImage.get();
 		// Handle remove post thumbnail click
-		if( event && event.target && 'remove-post-thumbnail' === event.target.id && 'click' === event.type ) {
+		if (
+			event &&
+			event.target &&
+			'remove-post-thumbnail' === event.target.id &&
+			'click' === event.type
+		) {
 			hasMedia = -1;
 		}
 
 		const tweetNow = $('#tweet_now').length;
 		const autoshareEnabled = $tweetPost.prop('checked');
 		// Autoshare is enabled and post has featured image.
-		if ( hasMedia > 0 && ( autoshareEnabled || tweetNow ) ) {
+		if (hasMedia > 0 && (autoshareEnabled || tweetNow)) {
 			allowTweetImageWrap.show();
 		} else {
 			allowTweetImageWrap.hide();
@@ -240,56 +270,73 @@
 	}
 
 	// Tweet Now functionality.
-	$('#tweet_now').on('click', function() {
-		$("#autoshare-for-twitter-error-message").html('');
-		$(this).addClass("disabled");
-		$(".autoshare-for-twitter-tweet-now-wrapper span.spinner").addClass("is-active");
+	$('#tweet_now').on('click', function () {
+		$('#autoshare-for-twitter-error-message').html('');
+		$(this).addClass('disabled');
+		$('.autoshare-for-twitter-tweet-now-wrapper span.spinner').addClass(
+			'is-active'
+		);
 
-		const postId = $("#post_ID").val();
+		const postId = $('#post_ID').val();
 		const body = new FormData();
-		body.append( 'action', adminAutoshareForTwitter.retweetAction );
-		body.append( 'nonce', adminAutoshareForTwitter.nonce );
-		body.append( 'post_id', postId );
-		body.append( 'is_classic', 1 );
+		body.append('action', adminAutoshareForTwitter.retweetAction);
+		body.append('nonce', adminAutoshareForTwitter.nonce);
+		body.append('post_id', postId);
+		body.append('is_classic', 1);
 
 		// Send request to Tweet now.
-		fetch( ajaxurl, {
+		fetch(ajaxurl, {
 			method: 'POST',
 			body,
-		} )
-		.then((response) => response.json())
-		.then((response) => {
-			if (
-				response && response.data &&
-				( ( response.success && response.data.message ) || ( false === response.success && false === response.data.is_retweeted) )
-			) {
-				$('.autoshare-for-twitter-status-logs-wrapper').html(response.data.message);
-				if ( response.data.is_retweeted ) {
-					$tweetText.val(''); // Reset the tweet text.
+		})
+			.then((response) => response.json())
+			.then((response) => {
+				if (
+					response &&
+					response.data &&
+					((response.success && response.data.message) ||
+						(false === response.success &&
+							false === response.data.is_retweeted))
+				) {
+					$('.autoshare-for-twitter-status-logs-wrapper').html(
+						response.data.message
+					);
+					if (response.data.is_retweeted) {
+						$tweetText.val(''); // Reset the tweet text.
+					}
+				} else {
+					$('#autoshare-for-twitter-error-message').html(
+						adminAutoshareForTwitter.unknownErrorText
+					);
 				}
-			} else {
-				$("#autoshare-for-twitter-error-message").html(adminAutoshareForTwitter.unknownErrorText);
-			}
-		})
-		.catch((error) => {
-			if(error.message){
-				$("#autoshare-for-twitter-error-message").html(error.message);
-			} else {
-				$("#autoshare-for-twitter-error-message").html(adminAutoshareForTwitter.unknownErrorText);
-			}
-		})
-		.finally(() => {
-			$(this).removeClass("disabled");
-			$(".autoshare-for-twitter-tweet-now-wrapper span.spinner").removeClass("is-active");
-		});
+			})
+			.catch((error) => {
+				if (error.message) {
+					$('#autoshare-for-twitter-error-message').html(
+						error.message
+					);
+				} else {
+					$('#autoshare-for-twitter-error-message').html(
+						adminAutoshareForTwitter.unknownErrorText
+					);
+				}
+			})
+			.finally(() => {
+				$(this).removeClass('disabled');
+				$(
+					'.autoshare-for-twitter-tweet-now-wrapper span.spinner'
+				).removeClass('is-active');
+			});
 	});
 
 	// Toggle Tweet Now panel
-	jQuery("#autoshare_for_twitter_metabox .tweet-now-button").on("click", function(e){
-		e.preventDefault();
-		$editBody.show();
-		jQuery(this).find('span').toggleClass('dashicons-arrow-up-alt2');
-		jQuery(".autoshare-for-twitter-tweet-now-wrapper").slideToggle();
-	});	
-
+	jQuery('#autoshare_for_twitter_metabox .tweet-now-button').on(
+		'click',
+		function (e) {
+			e.preventDefault();
+			$editBody.show();
+			jQuery(this).find('span').toggleClass('dashicons-arrow-up-alt2');
+			jQuery('.autoshare-for-twitter-tweet-now-wrapper').slideToggle();
+		}
+	);
 })(jQuery);

--- a/autoshare-for-twitter.php
+++ b/autoshare-for-twitter.php
@@ -26,6 +26,7 @@ define( 'AUTOSHARE_FOR_TWITTER_VERSION', '2.1.1' );
 define( 'AUTOSHARE_FOR_TWITTER_URL', plugin_dir_url( __FILE__ ) );
 define( 'AUTOSHARE_FOR_TWITTER_PATH', plugin_dir_path( __FILE__ ) );
 define( 'AUTOSHARE_FOR_TWITTER_INC', AUTOSHARE_FOR_TWITTER_PATH . 'includes/' );
+define( 'AUTOSHARE_FOR_TWITTER_URL_LENGTH', 23 );
 
 /**
  * Get the minimum version of PHP required by this plugin.
@@ -82,16 +83,6 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 // Include the main functionality.
 require_once plugin_dir_path( __FILE__ ) . 'includes/core.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/utils.php';
-
-/**
- * Setup environment variables
- */
-add_action(
-	'autoshare_for_twitter_loaded',
-	function () {
-		Utils\set_url_length();
-	}
-);
 
 /**
  * Play nice with others.

--- a/autoshare-for-twitter.php
+++ b/autoshare-for-twitter.php
@@ -26,6 +26,7 @@ define( 'AUTOSHARE_FOR_TWITTER_VERSION', '2.1.1' );
 define( 'AUTOSHARE_FOR_TWITTER_URL', plugin_dir_url( __FILE__ ) );
 define( 'AUTOSHARE_FOR_TWITTER_PATH', plugin_dir_path( __FILE__ ) );
 define( 'AUTOSHARE_FOR_TWITTER_INC', AUTOSHARE_FOR_TWITTER_PATH . 'includes/' );
+define( 'AUTOSHARE_FOR_TWITTER_URL_LENGTH', 23 );
 
 /**
  * Get the minimum version of PHP required by this plugin.

--- a/autoshare-for-twitter.php
+++ b/autoshare-for-twitter.php
@@ -26,7 +26,6 @@ define( 'AUTOSHARE_FOR_TWITTER_VERSION', '2.1.1' );
 define( 'AUTOSHARE_FOR_TWITTER_URL', plugin_dir_url( __FILE__ ) );
 define( 'AUTOSHARE_FOR_TWITTER_PATH', plugin_dir_path( __FILE__ ) );
 define( 'AUTOSHARE_FOR_TWITTER_INC', AUTOSHARE_FOR_TWITTER_PATH . 'includes/' );
-define( 'AUTOSHARE_FOR_TWITTER_URL_LENGTH', 23 );
 
 /**
  * Get the minimum version of PHP required by this plugin.
@@ -50,14 +49,14 @@ function site_meets_php_requirements() {
 if ( ! site_meets_php_requirements() ) {
 	add_action(
 		'admin_notices',
-		function() {
+		function () {
 			?>
 			<div class="notice notice-error">
 				<p>
 					<?php
 					echo wp_kses_post(
 						sprintf(
-							/* translators: %s: Minimum required PHP version */
+						/* translators: %s: Minimum required PHP version */
 							__( 'Autoshare for Twitter requires PHP version %s or later. Please upgrade PHP or disable the plugin.', 'autoshare-for-twitter' ),
 							esc_html( minimum_php_requirement() )
 						)
@@ -68,6 +67,7 @@ if ( ! site_meets_php_requirements() ) {
 			<?php
 		}
 	);
+
 	return;
 }
 
@@ -82,6 +82,16 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 // Include the main functionality.
 require_once plugin_dir_path( __FILE__ ) . 'includes/core.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/utils.php';
+
+/**
+ * Setup environment variables
+ */
+add_action(
+	'autoshare_for_twitter_loaded',
+	function () {
+		Utils\set_url_length();
+	}
+);
 
 /**
  * Play nice with others.

--- a/includes/admin/assets.php
+++ b/includes/admin/assets.php
@@ -211,6 +211,7 @@ function localize_data( $handle = SCRIPT_HANDLE ) {
 		'tweetAccounts'      => $tweet_accounts,
 		'tweetAccountsKey'   => TWEET_ACCOUNTS_KEY,
 		'connectedAccounts'  => $accounts ?? [],
+		'twitterURLLength'   => AUTOSHARE_FOR_TWITTER_URL_LENGTH,
 	];
 
 	wp_localize_script( $handle, 'adminAutoshareForTwitter', $localization );

--- a/includes/admin/assets.php
+++ b/includes/admin/assets.php
@@ -17,6 +17,7 @@ use function TenUp\AutoshareForTwitter\Utils\autoshare_enabled;
 use function TenUp\AutoshareForTwitter\Utils\tweet_image_allowed;
 use function TenUp\AutoshareForTwitter\Utils\get_tweet_accounts;
 use function TenUp\AutoshareForTwitter\Utils\get_default_autoshare_accounts;
+use function TenUp\AutoshareForTwitter\Utils\is_local;
 
 use const TenUp\AutoshareForTwitter\Core\Post_Meta\ENABLE_AUTOSHARE_FOR_TWITTER_KEY;
 use const TenUp\AutoshareForTwitter\Core\Post_Meta\TWEET_ACCOUNTS_KEY;
@@ -211,6 +212,7 @@ function localize_data( $handle = SCRIPT_HANDLE ) {
 		'tweetAccounts'      => $tweet_accounts,
 		'tweetAccountsKey'   => TWEET_ACCOUNTS_KEY,
 		'connectedAccounts'  => $accounts ?? [],
+		'isLocalSite'        => is_local(),
 		'twitterURLLength'   => AUTOSHARE_FOR_TWITTER_URL_LENGTH,
 	];
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -222,7 +222,7 @@ function compose_tweet_body( \WP_Post $post ) {
 
 	$url = esc_url( $url );
 	// According to this page https://developer.twitter.com/en/docs/counting-characters, all URLs are transformed to a uniform length.
-	$url_length        = AUTOSHARE_FOR_TWITTER_URL_LENGTH ? AUTOSHARE_FOR_TWITTER_URL_LENGTH : strlen( $url );
+	$url_length        = ( ! is_local() ) ? AUTOSHARE_FOR_TWITTER_URL_LENGTH : strlen( $url );
 	$body_max_length   = 275 - $url_length; // 275 instead of 280 because of the space between body and URL and the ellipsis.
 	$tweet_body        = sanitize_text_field( $tweet_body );
 	$tweet_body        = html_entity_decode( $tweet_body, ENT_QUOTES, get_bloginfo( 'charset' ) );
@@ -457,17 +457,4 @@ function is_local() {
 	 * @param bool $is_local whether WP environment is local or not.
 	 */
 	return apply_filters( 'autoshare_for_twitter_is_local', $is_local );
-}
-
-/**
- * Function to set the AUTOSHARE_FOR_TWITTER_URL_LENGTH value based on environment
- */
-function set_url_length() {
-	if ( is_local() ) {
-		// When set to false, the JS tools will calculate the _real_ hypothetical URL length, and the php tools will use the real length.
-		define( 'AUTOSHARE_FOR_TWITTER_URL_LENGTH', false );
-	} else {
-		// This should be updated if Twitter/X ever update the t.co URL shortening length.
-		define( 'AUTOSHARE_FOR_TWITTER_URL_LENGTH', 23 );
-	}
 }

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -214,7 +214,9 @@ function compose_tweet_body( \WP_Post $post ) {
 	$url = apply_filters( 'autoshare_for_twitter_post_url', get_the_permalink( $post->ID ), $post );
 
 	$url               = esc_url( $url );
-	$body_max_length   = 275 - strlen( $url ); // 275 instead of 280 because of the space between body and URL and the ellipsis.
+	// According to this page https://developer.twitter.com/en/docs/counting-characters, all URLs are transformed to a uniform length.
+	$url_length        = AUTOSHARE_FOR_TWITTER_URL_LENGTH ? AUTOSHARE_FOR_TWITTER_URL_LENGTH : strlen( $url );
+	$body_max_length   = 275 - $url_length; // 275 instead of 280 because of the space between body and URL and the ellipsis.
 	$tweet_body        = sanitize_text_field( $tweet_body );
 	$tweet_body        = html_entity_decode( $tweet_body, ENT_QUOTES, get_bloginfo( 'charset' ) );
 	$tweet_body_length = strlen( $tweet_body );

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -213,7 +213,7 @@ function compose_tweet_body( \WP_Post $post ) {
 	 */
 	$url = apply_filters( 'autoshare_for_twitter_post_url', get_the_permalink( $post->ID ), $post );
 
-	$url               = esc_url( $url );
+	$url = esc_url( $url );
 	// According to this page https://developer.twitter.com/en/docs/counting-characters, all URLs are transformed to a uniform length.
 	$url_length        = AUTOSHARE_FOR_TWITTER_URL_LENGTH ? AUTOSHARE_FOR_TWITTER_URL_LENGTH : strlen( $url );
 	$body_max_length   = 275 - $url_length; // 275 instead of 280 because of the space between body and URL and the ellipsis.

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -19,7 +19,7 @@ use const TenUp\AutoshareForTwitter\Core\Post_Meta\TWEET_ALLOW_IMAGE;
 /**
  * Helper/Wrapper function for returning the meta entries for autosharing.
  *
- * @param int    $id  The post ID.
+ * @param int    $id The post ID.
  * @param string $key The meta key to retrieve.
  *
  * @return mixed
@@ -30,11 +30,11 @@ function get_autoshare_for_twitter_meta( $id, $key ) {
 	/**
 	 * Filters autoshare metadata.
 	 *
-	 * @since 1.0.0
-	 *
 	 * @param mixed  Retrieved metadata.
 	 * @param int    Post ID.
 	 * @param string The meta key.
+	 *
+	 * @since 1.0.0
 	 */
 	return apply_filters( 'autoshare_for_twitter_meta', $data, $id, $key );
 }
@@ -42,9 +42,10 @@ function get_autoshare_for_twitter_meta( $id, $key ) {
 /**
  * Updates autoshare-for-twitter-related post metadata by prefixing the passed key.
  *
- * @param int    $id    Post ID.
- * @param string $key   Autoshare meta key.
+ * @param int    $id Post ID.
+ * @param string $key Autoshare meta key.
  * @param mixed  $value The meta value to save.
+ *
  * @return mixed The meta_id if the meta doesn't exist, otherwise returns true on success and false on failure.
  */
 function update_autoshare_for_twitter_meta( $id, $key, $value ) {
@@ -54,8 +55,9 @@ function update_autoshare_for_twitter_meta( $id, $key, $value ) {
 /**
  * Determines whether an Autoshare for Twitter post meta key exists on the provided post.
  *
- * @param int    $id  A Post ID.
+ * @param int    $id A Post ID.
  * @param string $key A meta key.
+ *
  * @return boolean
  */
 function has_autoshare_for_twitter_meta( $id, $key ) {
@@ -65,8 +67,9 @@ function has_autoshare_for_twitter_meta( $id, $key ) {
 /**
  * Deletes autoshare-for-twitter-related metadata.
  *
- * @param int    $id  The post ID.
+ * @param int    $id The post ID.
  * @param string $key The key of the meta value to delete.
+ *
  * @return boolean False for failure. True for success.
  */
 function delete_autoshare_for_twitter_meta( $id, $key ) {
@@ -77,6 +80,7 @@ function delete_autoshare_for_twitter_meta( $id, $key ) {
  * Returns whether autoshare is enabled for a post.
  *
  * @param int $post_id A post ID.
+ *
  * @return boolean
  */
 function autoshare_enabled( $post_id ) {
@@ -98,6 +102,7 @@ function autoshare_enabled( $post_id ) {
  * Returns whether image is allowed in a tweet.
  *
  * @param int $post_id A post ID.
+ *
  * @return boolean
  */
 function tweet_image_allowed( $post_id ) {
@@ -121,6 +126,7 @@ function tweet_image_allowed( $post_id ) {
  * Returns tweet enabled Twitter accounts for the post.
  *
  * @param int $post_id A post ID.
+ *
  * @return array
  */
 function get_tweet_accounts( $post_id ) {
@@ -189,6 +195,7 @@ function is_twitter_configured() {
 
 	$settings    = get_autoshare_for_twitter_settings();
 	$credentials = array_intersect_key( $settings, $defaults );
+
 	return 2 === count( array_filter( $credentials ) );
 }
 
@@ -277,11 +284,10 @@ function link_from_twitter( $tweet_status ) {
 /**
  * Determine if a post has already been published based on the meta entry alone.
  *
- * @internal does NOT query the Twitter API.
- *
  * @param int $post_id The post id.
  *
  * @return bool
+ * @internal does NOT query the Twitter API.
  */
 function already_published( $post_id ) {
 
@@ -367,8 +373,9 @@ function get_post_types_supported_by_default() {
 	/**
 	 * Filters post types supported by default.
 	 *
-	 * @since 1.0.0
 	 * @param array Array of post types.
+	 *
+	 * @since 1.0.0
 	 */
 	return (array) apply_filters( 'autoshare_for_twitter_default_post_types', [ 'post', 'page' ] );
 }
@@ -386,9 +393,10 @@ function get_hardcoded_supported_post_types() {
 	$available_post_types = get_available_post_types();
 	$enabled_post_types   = get_autoshare_for_twitter_settings( 'post_types' );
 	$remaining            = array_diff( $available_post_types, $enabled_post_types );
+
 	return array_filter(
 		$remaining,
-		function( $post_type ) {
+		function ( $post_type ) {
 			return post_type_supports( $post_type, POST_TYPE_SUPPORT_FEATURE );
 		}
 	);
@@ -404,6 +412,7 @@ function get_enabled_post_types() {
 	if ( 'all' === $enable_for ) {
 		return get_available_post_types();
 	}
+
 	return get_autoshare_for_twitter_settings( 'post_types' );
 }
 
@@ -416,7 +425,7 @@ function get_enabled_post_types() {
  */
 function mask_secure_values( $value ) {
 	$count  = strlen( $value );
-	$substr = substr( $value, -5 );
+	$substr = substr( $value, - 5 );
 	$return = str_pad( $substr, $count, '*', STR_PAD_LEFT );
 
 	return $return;
@@ -429,4 +438,36 @@ function mask_secure_values( $value ) {
  */
 function get_default_autoshare_accounts() {
 	return get_autoshare_for_twitter_settings( 'autoshare_accounts' );
+}
+
+
+/**
+ * Returns whether WP environment is local.
+ *
+ * @return bool
+ */
+function is_local() {
+	$is_local_env = in_array( wp_get_environment_type(), [ 'local', 'development' ], true );
+	$is_local_url = strpos( home_url(), '.test' ) || strpos( home_url(), '.local' );
+	$is_local     = $is_local_env || $is_local_url;
+
+	/**
+	 * Filters whether WP environment is local or not.
+	 *
+	 * @param bool $is_local whether WP environment is local or not.
+	 */
+	return apply_filters( 'autoshare_for_twitter_is_local', $is_local );
+}
+
+/**
+ * Function to set the AUTOSHARE_FOR_TWITTER_URL_LENGTH value based on environment
+ */
+function set_url_length() {
+	if ( is_local() ) {
+		// When set to false, the JS tools will calculate the _real_ hypothetical URL length, and the php tools will use the real length.
+		define( 'AUTOSHARE_FOR_TWITTER_URL_LENGTH', false );
+	} else {
+		// This should be updated if Twitter/X ever update the t.co URL shortening length.
+		define( 'AUTOSHARE_FOR_TWITTER_URL_LENGTH', 23 );
+	}
 }

--- a/src/js/components/TweetTextField.js
+++ b/src/js/components/TweetTextField.js
@@ -3,10 +3,15 @@ import { useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { useTweetText } from '../hooks';
 import { useEffect, useState } from '@wordpress/element';
-const { siteUrl } = adminAutoshareForTwitter;
+const { siteUrl, twitterURLLength } = adminAutoshareForTwitter;
 
 export function TweetTextField() {
 	const getPermalinkLength = ( select ) => {
+		if ( twitterURLLength ) {
+			// according to this page https://developer.twitter.com/en/docs/counting-characters, all URLs are transformed to a uniform length
+			return twitterURLLength;
+		}
+
 		const permalink = select( 'core/editor' ).getPermalink();
 
 		if ( permalink ) {

--- a/src/js/components/TweetTextField.js
+++ b/src/js/components/TweetTextField.js
@@ -3,13 +3,14 @@ import { useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { useTweetText } from '../hooks';
 import { useEffect, useState } from '@wordpress/element';
+
 const { siteUrl, twitterURLLength } = adminAutoshareForTwitter;
 
 export function TweetTextField() {
 	const getPermalinkLength = ( select ) => {
 		if ( twitterURLLength ) {
 			// according to this page https://developer.twitter.com/en/docs/counting-characters, all URLs are transformed to a uniform length
-			return twitterURLLength;
+			return Number( twitterURLLength );
 		}
 
 		const permalink = select( 'core/editor' ).getPermalink();

--- a/src/js/components/TweetTextField.js
+++ b/src/js/components/TweetTextField.js
@@ -4,12 +4,12 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useTweetText } from '../hooks';
 import { useEffect, useState } from '@wordpress/element';
 
-const { siteUrl, twitterURLLength } = adminAutoshareForTwitter;
+const { siteUrl, isLocalSite, twitterURLLength } = adminAutoshareForTwitter;
 
 export function TweetTextField() {
 	const getPermalinkLength = ( select ) => {
-		if ( twitterURLLength ) {
-			// according to this page https://developer.twitter.com/en/docs/counting-characters, all URLs are transformed to a uniform length
+		if ( ! isLocalSite && ! isNaN( twitterURLLength ) ) {
+			// According to this page https://developer.twitter.com/en/docs/counting-characters, all URLs are transformed to a uniform length
 			return Number( twitterURLLength );
 		}
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
There were a couple of issues present having to do with the calculation of tweet length. 

First, the calculation for the Classic Editor was using the permalink preview to calculate the hypothetical permalink length. That's great until the permalink gets long, and then the preview is shortened with "...". So, the real permalink would be longer than the calculated one. 

Second, Twitter currently shortens all URLs to 23 characters. So, technically, any URL should just be calculated as 23 characters. 

From https://developer.twitter.com/en/docs/counting-characters
> URLs: [All URLs are wrapped in t.co links](https://developer.twitter.com/content/developer-twitter/en/docs/basics/tco). This means a URL’s length is defined by the transformedURLLength parameter in the [twitter-text configuration file](https://github.com/twitter/twitter-text/tree/master/config). The current length of a URL in a Tweet is 23 characters, even if the length of the URL would normally be shorter.

From https://developer.twitter.com/en/docs/tco, evidently there's an API endpoint that returns the current maximum URL length. In some cases, shorter URLs may not reach the maximum length, but in all cases, the maximum is the maximum. 

In this PR, I: 
- Set up a new constant, `AUTOSHARE_FOR_TWITTER_URL_LENGTH`, to store the current URL length published by Twitter. This could be set to false to revert to using the real URL lengths. This could be refactored to get the most current value from the `help/configuration` endpoint, as [described here](https://developer.twitter.com/en/docs/tco).
- Localized that Twitter URL length value in `localize_data()` as `adminAutoshareForTwitter.twitterURLLength`.
- Added a way of calculating the accurate hypothetical permalink length for the Classic Editor (I haven't worked with Gutenberg much, and did not spend any time checking the implementation there).
- Set the default behavior everywhere to use the twitterURLLength value _instead_ of the actual permalink length. twitterURLLength can be set to false in the `localize_data()` implementation to force real permalink calculations (because each implementation falls back to real permalink calculation when the `twitterURLLength` is false.
- Modified the `compose_tweet_body()` method to also use the defined twitter URL length for its calculations.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
To be honest, I am not familiar with the Cypress framework enough to write an automated test. And I'm not sure if all of the files I've touched are in scope for those types of tests anyway. I would be happy to help pair-program tests for this, or dialogue about them here.

To manually test the correct functionality, there are two scenarios to test: 1) the correct default, which is to treat all URLs as the same length and 2) the fallback, in case we want to disable that feature. 

**To test the fallback**
- [ ] Set the `AUTOSHARE_FOR_TWITTER_URL_LENGTH` value to `false` in the main plugin file. 
- [ ] Start a new post. 
- [ ] Write a title that exceeds WordPress's permalink preview length (e.g. "This is my super duper, really long post title that definitely isn't going to fit in the preview"). 
- [ ] The calculated tweet length should be exactly the length of the intended permalink plus the 5-character padding. 
- [ ] Then try to write a custom tweet. 
- [ ] The tweet body validation should properly use the real permalink length, so that the calculated length is the true permalink + the length of the message + the 5-character padding.

**To test the currently-intended behavior**
- [ ] Set the `AUTOSHARE_FOR_TWITTER_URL_LENGTH` value back to `23` in the main plugin file. 
- [ ] Start a new post. 
- [ ] Write a title that exceeds WordPress's permalink preview length (e.g. "This is my super duper, really long post title that definitely isn't going to fit in the preview"). 
- [ ] Try to customize the tweet with content that is exactly 252 characters long. 280 - 23 (the current maximum URL length for tweets) - 5 (the pre-existing padding used for the plugin). 
- [ ] The tweet should be successful/valid at 252 characters, no matter what the URL length.

This should work in Classic Editor and Gutenberg (I think, but wasn't sure about the plugin build process). In both cases, the Tweet should successfully send without errors when the post is published.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Bug fix for issues calculating tweet length


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @justinmaurerdotdev


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [see my comments above] I have added tests to cover my change.
- [?] All new and existing tests pass. 
I get `Error: ENOENT: no such file or directory, scandir '/Users/justinmaurer/.wp-env'` When I try to run the `cypress:run` script. I'm not really familiar with `.wp-env` and don't know what's expected to be in there (or how to set it up).

I'm aware there is probably some discussion or cleanup needed to make my commits fit the package standards, but I wanted to submit it at this stage to get some feedback about what exactly is missing, and whether there's some other plan (or better way) to handle this.