### PR TITLE
Fix auto-posting tweets for automatically published posts.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7",
 		"10up/phpcs-composer": "dev-master",
 		"phpunit/phpunit": "9.6.x-dev",
-		"yoast/phpunit-polyfills": "2.x-dev"
+		"yoast/phpunit-polyfills": "2.0.0"
 	},
 	"scripts": {
 		"test": "phpunit",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc6e4242cfc2df2ee3c988aa552f8c64",
+    "content-hash": "8421a957f988a1a59e6c57ec9246f7a6",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -2399,21 +2399,21 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "dev-main",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171"
+                "reference": "c758753e8f9dac251fed396a73c8305af3f17922"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/c758753e8f9dac251fed396a73c8305af3f17922",
+                "reference": "c758753e8f9dac251fed396a73c8305af3f17922",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "php": ">=5.6",
+                "phpunit/phpunit": "^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
             },
             "require-dev": {
                 "yoast/yoastcs": "^2.3.0"
@@ -2455,15 +2455,14 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2023-03-30T23:39:05+00:00"
+            "time": "2023-06-06T20:28:24+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
         "10up/phpcs-composer": 20,
-        "phpunit/phpunit": 20,
-        "yoast/phpunit-polyfills": 20
+        "phpunit/phpunit": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/includes/admin/assets.php
+++ b/includes/admin/assets.php
@@ -16,7 +16,6 @@ use function TenUp\AutoshareForTwitter\REST\post_autoshare_for_twitter_meta_rest
 use function TenUp\AutoshareForTwitter\Utils\autoshare_enabled;
 use function TenUp\AutoshareForTwitter\Utils\tweet_image_allowed;
 use function TenUp\AutoshareForTwitter\Utils\get_tweet_accounts;
-use function TenUp\AutoshareForTwitter\Utils\get_default_autoshare_accounts;
 
 use const TenUp\AutoshareForTwitter\Core\Post_Meta\ENABLE_AUTOSHARE_FOR_TWITTER_KEY;
 use const TenUp\AutoshareForTwitter\Core\Post_Meta\TWEET_ACCOUNTS_KEY;

--- a/includes/admin/assets.php
+++ b/includes/admin/assets.php
@@ -189,9 +189,6 @@ function localize_data( $handle = SCRIPT_HANDLE ) {
 	$accounts       = ( new Twitter_Accounts() )->get_twitter_accounts( true );
 	$tweet_accounts = get_tweet_accounts( $post_id );
 	$tweet_body     = trim( get_autoshare_for_twitter_meta( $post_id, TWEET_BODY_KEY ) );
-	if ( empty( $tweet_accounts ) ) {
-		$tweet_accounts = get_default_autoshare_accounts();
-	}
 
 	$localization = [
 		'enabled'            => autoshare_enabled( $post_id ),

--- a/includes/admin/post-meta.php
+++ b/includes/admin/post-meta.php
@@ -291,9 +291,7 @@ function render_twitter_accounts( $post_id ) {
 	}
 
 	$enabled = Utils\get_tweet_accounts( $post_id );
-	if ( empty( $enabled ) ) {
-		$enabled = Utils\get_default_autoshare_accounts();
-	}
+
 	$display = ( autoshare_enabled( $post_id ) || 'publish' === $post_status ) ? '' : 'display: none;';
 	?>
 	<div class="autoshare-for-twitter-accounts-wrapper" style="<?php echo esc_attr( $display ); ?>">

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -124,8 +124,15 @@ function tweet_image_allowed( $post_id ) {
  * @return array
  */
 function get_tweet_accounts( $post_id ) {
-	$tweet_accounts = get_autoshare_for_twitter_meta( $post_id, TWEET_ACCOUNTS_KEY );
-	if ( empty( $tweet_accounts ) ) {
+	$tweet_accounts = [];
+	if ( has_autoshare_for_twitter_meta( $post_id, TWEET_ACCOUNTS_KEY ) ) {
+		$tweet_accounts = get_autoshare_for_twitter_meta( $post_id, TWEET_ACCOUNTS_KEY );
+	} else {
+		// If post don't have meta value set for tweet accounts, use default enabled accounts to handle auto-tweet for automated posts.
+		$tweet_accounts = get_default_autoshare_accounts();
+	}
+
+	if ( ! is_array( $tweet_accounts ) ) {
 		$tweet_accounts = [];
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"cypress-mochawesome-reporter": "^3.5.1",
 				"husky": "^3.0.5",
 				"lint-staged": "^9.2.5",
+				"mochawesome-json-to-md": "^0.7.2",
 				"node-wp-i18n": "^1.2.3"
 			}
 		},
@@ -14534,6 +14535,18 @@
 			},
 			"peerDependencies": {
 				"mocha": ">=7"
+			}
+		},
+		"node_modules/mochawesome-json-to-md": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/mochawesome-json-to-md/-/mochawesome-json-to-md-0.7.2.tgz",
+			"integrity": "sha512-dxh+o73bhC6nEph6fNky9wy35R+2oK3ueXwAlJ/COAanlFgu8GuvGzQ00VNO4PPYhYGDsO4vbt4QTcMA3lv25g==",
+			"dev": true,
+			"dependencies": {
+				"yargs": "^17.0.1"
+			},
+			"bin": {
+				"mochawesome-json-to-md": "index.js"
 			}
 		},
 		"node_modules/mochawesome-merge": {
@@ -31535,6 +31548,15 @@
 				"mochawesome-report-generator": "^6.2.0",
 				"strip-ansi": "^6.0.1",
 				"uuid": "^8.3.2"
+			}
+		},
+		"mochawesome-json-to-md": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/mochawesome-json-to-md/-/mochawesome-json-to-md-0.7.2.tgz",
+			"integrity": "sha512-dxh+o73bhC6nEph6fNky9wy35R+2oK3ueXwAlJ/COAanlFgu8GuvGzQ00VNO4PPYhYGDsO4vbt4QTcMA3lv25g==",
+			"dev": true,
+			"requires": {
+				"yargs": "^17.0.1"
 			}
 		},
 		"mochawesome-merge": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"cypress-mochawesome-reporter": "^3.5.1",
 		"husky": "^3.0.5",
 		"lint-staged": "^9.2.5",
+		"mochawesome-json-to-md": "^0.7.2",
 		"node-wp-i18n": "^1.2.3"
 	},
 	"prettier": "@wordpress/prettier-config"


### PR DESCRIPTION
### Description of the Change
The PR addresses issues with auto-posting tweets for automatically published posts. Currently, tweets are posted based only on tweet accounts saved in post meta, and these tweet accounts are saved to post meta in the edit post screen. Because of this, when posts are automatically published, they don't get tweeted. The PR resolves this issue by tweeting posts to accounts with auto-share enabled by default when post meta is not saved in the post.

Closes #287 
Closes #286 

### How to test the Change
1. Install and set up the plugin.
1. Connect Twitter account.
1. Enabled Autoshare by default on the connected account.
1. Automatically publish post, It can be done via the below code snippet or you can follow any other way to do this.
```php
add_action( 'init', function(){
	// Create a new post.
	wp_insert_post(
		array(
			'post_title'  => 'Test Title',
			'post_status' => 'publish',
		)
	);
});
```
1. Verify that the post has been tweeted.

### Changelog Entry
> Fixed - Auto-posting tweets for automatically published posts.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @iamdharmesh @sunnmagic


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
