### PR TITLE
Made an implicit float to integer conversion explicit to fix PHP 8.2 deprecation warning

### DIFF
--- a/includes/class-ast-staging.php
+++ b/includes/class-ast-staging.php
@@ -175,7 +175,7 @@ class AST_Staging {
 		$scheme = wp_parse_url( $url, PHP_URL_SCHEME ) . '://';
 		$url    = str_replace( $scheme, '', $url );
 
-		return $scheme . substr_replace( $url, '_[autoshare_liveurl]_', intval(strlen( $url ) / 2), 0 );
+		return $scheme . substr_replace( $url, '_[autoshare_liveurl]_', intval( strlen( $url ) / 2 ), 0 );
 	}
 
 	/**

--- a/includes/class-ast-staging.php
+++ b/includes/class-ast-staging.php
@@ -175,7 +175,7 @@ class AST_Staging {
 		$scheme = wp_parse_url( $url, PHP_URL_SCHEME ) . '://';
 		$url    = str_replace( $scheme, '', $url );
 
-		return $scheme . substr_replace( $url, '_[autoshare_liveurl]_', strlen( $url ) / 2, 0 );
+		return $scheme . substr_replace( $url, '_[autoshare_liveurl]_', intval(strlen( $url ) / 2), 0 );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
The string replacement was based on a calculation of _half_ of the URL's length. When that length is an odd number, the `substr_replace` function was getting a decimal instead of an integer, which throws a deprecation warning about "implicit float to int conversion" in PHP 8.2.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
The staging handling for autopost functionality should still work, and the warning about a site change being detected should be displayed in the dashboard while working on staging or development environments.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - minor deprecation warning about implicit float to int conversion


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @justinmaurerdotdev 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.

I was not able to get my tests to pass because of this error in the `phpcs` pre-commit process:
```FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
1 | ERROR | An error occurred during processing; checking has been
  |       | aborted. The error message was: trim(): Passing null to
  |       | parameter #1 ($string) of type string is deprecated in
  |       | .../wp-content/plugins/autoshare-for-twitter/vendor/wp-coding-standards/wpcs/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
  |       | on line 280 (Internal.Exception)
----------------------------------------------------------------------
```