### PR TITLE
Fix url params in post url

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -8,6 +8,10 @@
 
 namespace TenUp\AutoshareForTwitter\Utils;
 
+use DateTime;
+use DateTimeZone;
+use WP_Post;
+use const TenUp\AutoshareForTwitter\Core\Admin\AT_SETTINGS;
 use const TenUp\AutoshareForTwitter\Core\POST_TYPE_SUPPORT_FEATURE;
 use const TenUp\AutoshareForTwitter\Core\Post_Meta\ENABLE_AUTOSHARE_FOR_TWITTER_KEY;
 use const TenUp\AutoshareForTwitter\Core\Post_Meta\META_PREFIX;
@@ -170,7 +174,7 @@ function get_autoshare_for_twitter_settings( $key = '' ) {
 		'autoshare_accounts' => [],
 	];
 
-	$settings = get_option( \TenUp\AutoshareForTwitter\Core\Admin\AT_SETTINGS );
+	$settings = get_option( AT_SETTINGS );
 
 	if ( empty( $settings ) ) {
 		$settings = [];
@@ -209,11 +213,11 @@ function is_twitter_configured() {
 /**
  * Composes the tweet based off Title and URL.
  *
- * @param \WP_Post $post The post object.
+ * @param WP_Post $post The post object.
  *
  * @return string
  */
-function compose_tweet_body( \WP_Post $post ) {
+function compose_tweet_body( WP_Post $post ) {
 
 	/**
 	 * Allow filtering of tweet body
@@ -227,7 +231,7 @@ function compose_tweet_body( \WP_Post $post ) {
 	 */
 	$url = apply_filters( 'autoshare_for_twitter_post_url', get_the_permalink( $post->ID ), $post );
 
-	$url = esc_url( $url );
+	$url = esc_url_raw( $url );
 	// According to this page https://developer.twitter.com/en/docs/counting-characters, all URLs are transformed to a uniform length.
 	$url_length        = ( ! is_local() ) ? AUTOSHARE_FOR_TWITTER_URL_LENGTH : strlen( $url );
 	$body_max_length   = 275 - $url_length; // 275 instead of 280 because of the space between body and URL and the ellipsis.
@@ -267,8 +271,8 @@ function date_from_twitter( $created_at ) {
 
 	$tz   = get_option( 'timezone_string' );
 	$tz   = ( ! empty( $tz ) ) ? $tz : 'UTC';
-	$date = new \DateTime( $created_at, new \DateTimeZone( 'UTC' ) );
-	$date->setTimezone( new \DateTimeZone( $tz ) );
+	$date = new DateTime( $created_at, new DateTimeZone( 'UTC' ) );
+	$date->setTimezone( new DateTimeZone( $tz ) );
 
 	return $date->format( 'Y-m-d @ g:iA' );
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This addresses/closes: https://github.com/10up/autoshare-for-twitter/issues/323

The Tweet URL was being escaped by `esc_url()`, which converts ampersands to HTML entities, breaking any query parameters. 
Example: `http://example.org/?p=16&#038;utm_source=x&#038;utm_medium=social&#038;utm_campaign=my_test&#038;utm_content=auto-tweet&#038;utm_term=post`

Changing the escaping to use `esc_url_raw()` seems appropriate (since the URL isn't intended for HTML rendering, but an actual link) and fixes the problem. 
Example: `"http://example.org/?p=16&utm_source=x&utm_medium=social&utm_campaign=my_test&utm_content=auto-tweet&utm_term=post`

Note: It looks like PHPCBF got a little excited about replacing global class references (e.g. `\WP_Post`) with `use` statements in includes/utils.php. Let me know if those should not added and I can revert those bits. 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
I've added `test_filter_url_with_params()` to `TestPublish_Tweet.php`, and it is working as expected (fails with `esc_url()` and succeeds with `esc_url_raw()`. But, you can also just add a filter to see the behavior.

```
add_filter(
	'autoshare_for_twitter_post_url',
	function ( $url ) {
		return add_query_arg( array(
			'utm_source'   => 'x',
			'utm_medium'   => 'social',
			'utm_campaign' => 'my_test',
			'utm_content'  => 'auto-tweet',
			'utm_term'     => 'post',
		), $url );
	}
);
```

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Ampersands no longer converted to HTML entities when adding query parameters to the post URL with the 'autoshare_for_twitter_post_url' filter.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @justinmaurerdotdev 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
