### PR TITLE
Bump WordPress "tested up to" version 6.6

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Autopost for X (formerly Autoshare for Twitter) ===
 Contributors:      10up, johnwatkins0, adamsilverstein, scottlee, dinhtungdu, jeffpaul, dharm1025
 Tags:              twitter, tweet, share, social media, posse
-Tested up to:      6.5
+Tested up to:      6.6
 Stable tag:        2.2.1
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html


### PR DESCRIPTION
### Description of the Change

Bump WordPress "tested up to" version 6.6.

Closes #330 

### How to test the Change

Already tested in #330 

### Changelog Entry

> Changed - Bump WordPress "tested up to" version 6.6.

### Credits

Props @sudip-md, @dkotter.

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
