### PR TITLE
Bump Tested up to

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,7 +22,7 @@ jobs:
         core:
           - { name: 'WP latest', version: 'latest' }
           - { name: 'WP trunk', version: 'WordPress/WordPress#master' }
-          - { name: 'WP minimum', version: 'WordPress/WordPress#5.7' }
+          - { name: 'WP minimum', version: 'WordPress/WordPress#6.5' }
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ With Autopost for X, developers can further customize nearly everything about th
 ## Requirements
 
 - PHP 7.4+
-- [WordPress](http://wordpress.org) 5.7+
+- [WordPress](http://wordpress.org) 6.5+
 
 ## Installation
 

--- a/autoshare-for-twitter.php
+++ b/autoshare-for-twitter.php
@@ -4,7 +4,7 @@
  * Description:       Automatically shares the post title or custom message and a link to the post to X/Twitter.
  * Disclaimer:        TWITTER, TWEET, RETWEET and the Twitter logo are trademarks of Twitter, Inc. or its affiliates.
  * Version:           2.2.1
- * Requires at least: 5.7
+ * Requires at least: 6.5
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Autopost for X (formerly Autoshare for Twitter) ===
 Contributors:      10up, johnwatkins0, adamsilverstein, scottlee, dinhtungdu, jeffpaul, dharm1025
 Tags:              twitter, tweet, share, social media, posse
-Tested up to:      6.6
+Tested up to:      6.7
 Stable tag:        2.2.1
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html


### PR DESCRIPTION
### Description of the Change

- I've tested the plugin on `6.7-RC1`, tested the auto post works correctly.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/autoshare-for-twitter/issues/346

### How to test the Change
-  Update to 6.7 release candidate, confirm plugin works as expected

### Changelog Entry
> Changed - Bump WordPress "tested up to" version 6.7.
> Changed - Bump WordPress minimum required from 5.7 to 6.5

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @thrijith, @jeffpaul 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
