### PR TITLE
Expose last X headers for extensability

### DIFF
--- a/includes/class-publish-tweet.php
+++ b/includes/class-publish-tweet.php
@@ -96,9 +96,10 @@ class Publish_Tweet {
 		 * @param array|object The response from the Twitter endpoint.
 		 * @param array        Data to send to the Twitter endpoint.
 		 * @param \WP_Post     The post associated with the tweet.
+		 * @param int|null     The Twitter account ID.
 		 * @param array        The headers from the last request.
 		 */
-		do_action( 'autoshare_for_twitter_after_status_update', $response, $update_data, $post, $last_headers );
+		do_action( 'autoshare_for_twitter_after_status_update', $response, $update_data, $post, $account_id, $last_headers );
 
 		return $response;
 	}

--- a/includes/class-publish-tweet.php
+++ b/includes/class-publish-tweet.php
@@ -87,14 +87,18 @@ class Publish_Tweet {
 		// Send tweet to Twitter.
 		$response = $this->twitter_api->tweet( $update_data );
 
+		// Get the last headers from the Twitter API.
+		$last_headers = $this->twitter_api->get_last_headers();
+
 		/**
 		 * Fires after the request to the Twitter endpoint had been made.
 		 *
 		 * @param array|object The response from the Twitter endpoint.
 		 * @param array        Data to send to the Twitter endpoint.
-		 * @param \WP_Post      The post associated with the tweet.
+		 * @param \WP_Post     The post associated with the tweet.
+		 * @param array        The headers from the last request.
 		 */
-		do_action( 'autoshare_for_twitter_after_status_update', $response, $update_data, $post );
+		do_action( 'autoshare_for_twitter_after_status_update', $response, $update_data, $post, $last_headers );
 
 		return $response;
 	}

--- a/includes/class-twitter-api.php
+++ b/includes/class-twitter-api.php
@@ -240,4 +240,13 @@ class Twitter_API {
 			return false;
 		}
 	}
+
+	/**
+	 * Get the HTTP headers from the most recent request.
+	 *
+	 * @return array
+	 */
+	public function get_last_headers() {
+		return $this->client->getLastXHeaders();
+	}
 }


### PR DESCRIPTION
I'm developing an add-on plugin for the Autopost for X plugin that shows X API usage statistics in the WordPress admin for a client. Since there's no dedicated endpoint to retrieve these stats, I'll rely on the headers returned by the API when a tweet is posted. By hooking into the `autoshare_for_twitter_after_status_update` action, I can access these headers and extract key information, such as the current rate limit and reset time.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Last X headers to `autoshare_for_twitter_after_status_update` hook.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @s3rgiosan

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
