### PR TITLE
Make the API rate limit wording clearer.

### DIFF
--- a/includes/core.php
+++ b/includes/core.php
@@ -516,7 +516,7 @@ function get_rate_limits_markup( $title, $remaining, $limit, $reset ) {
 		esc_html( $title ),
 		sprintf(
 			/* translators: %1$s: Remaining, %2$s: Limit */
-			esc_html__( '%1$s of %2$s requests available', 'autoshare-for-twitter' ),
+			esc_html__( '%1$s of %2$s requests remaining', 'autoshare-for-twitter' ),
 			esc_html( $remaining ),
 			esc_html( $limit )
 		),

--- a/includes/core.php
+++ b/includes/core.php
@@ -429,8 +429,6 @@ function human_readable_time( $timestamp, $date_format = '' ) {
 
 	$timestamp = (int) $timestamp;
 
-	$datetime = new \DateTime( '@' . $timestamp, new \DateTimeZone( 'UTC' ) );
-
 	if ( empty( $date_format ) ) {
 		$date_format = sprintf(
 			'%s %s',
@@ -438,11 +436,7 @@ function human_readable_time( $timestamp, $date_format = '' ) {
 			esc_html( get_option( 'time_format' ) )
 		);
 	}
-
-	$human_readable_time = $datetime->format( $date_format );
-	$human_readable_time = sprintf( '%s (UTC)', $human_readable_time );
-
-	return $human_readable_time;
+	return wp_date( $date_format, $timestamp );
 }
 
 /**

--- a/includes/core.php
+++ b/includes/core.php
@@ -522,7 +522,7 @@ function get_rate_limits_markup( $title, $remaining, $limit, $reset ) {
 		esc_html( $title ),
 		sprintf(
 			/* translators: %1$s: Remaining, %2$s: Limit */
-			esc_html__( '%1$s of %2$s', 'autoshare-for-twitter' ),
+			esc_html__( '%1$s of %2$s requests available', 'autoshare-for-twitter' ),
 			esc_html( $remaining ),
 			esc_html( $limit )
 		),

--- a/src/js/components/TwitterAccounts.js
+++ b/src/js/components/TwitterAccounts.js
@@ -198,7 +198,10 @@ function TwitterRateLimits( { title, remaining, limit, reset, tooltip } ) {
 				</Tooltip>{ ' ' }
 				{ sprintf(
 					/* translators: %1$s: Remaining, %2$s: Limit */
-					__( '%1$s of %2$s', 'autoshare-for-twitter' ),
+					__(
+						'%1$s of %2$s requests available',
+						'autoshare-for-twitter'
+					),
 					remaining ?? __( 'N/A', 'autoshare-for-twitter' ),
 					limit ?? __( 'N/A', 'autoshare-for-twitter' )
 				) }

--- a/src/js/components/TwitterAccounts.js
+++ b/src/js/components/TwitterAccounts.js
@@ -184,10 +184,9 @@ function TwitterRateLimits( { title, remaining, limit, reset, tooltip } ) {
 	if ( reset && settings?.formats?.datetime ) {
 		formattedResetTime = dateI18n(
 			settings.formats.datetime,
-			reset * 1000,
-			'UTC'
+			reset * 1000
 		);
-		formattedResetTime = sprintf( '%1$s (UTC)', formattedResetTime );
+		formattedResetTime = sprintf( 'Resets on %1$s', formattedResetTime );
 	}
 
 	return (

--- a/src/js/components/TwitterAccounts.js
+++ b/src/js/components/TwitterAccounts.js
@@ -198,7 +198,7 @@ function TwitterRateLimits( { title, remaining, limit, reset, tooltip } ) {
 				{ sprintf(
 					/* translators: %1$s: Remaining, %2$s: Limit */
 					__(
-						'%1$s of %2$s requests available',
+						'%1$s of %2$s requests remaining',
 						'autoshare-for-twitter'
 					),
 					remaining ?? __( 'N/A', 'autoshare-for-twitter' ),


### PR DESCRIPTION
### Description of the Change
As reported in #362, the wording for the remaining requests is currently unclear, which may confuse users. We are currently displaying "16 of 17", which could cause users to misinterpret whether **16** represents the remaining requests or those already used. This PR makes minor wording updates to clarify the limits by changing it to "16 of 17 requests remaining". Additionally, PR makes an update to display the reset time in the site's timezone instead of UTC.

![Screenshot 2025-03-29 at 11 05 50 PM](https://github.com/user-attachments/assets/427b7719-0672-470c-985d-5705dc18098d)

Closes #362 

### How to test the Change
1. Check the dashboard widget **"Autopost for X — Rate Monitor"** and verify that it reflects the wording correctly.  
2. Create a new post or edit an existing post and verify that the limit wording is updated in the **"Autopost for X" sidebar panel**.

### Changelog Entry
> Changed - Made the API rate limit wording clearer.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeckman @iamdharmesh 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
