### PR TITLE
Allow autotweeting of scheduled posts.

### DIFF
--- a/includes/admin/post-transition.php
+++ b/includes/admin/post-transition.php
@@ -106,11 +106,6 @@ function publish_tweet( $post_id, $force = false ) {
 		return false;
 	}
 
-	// Ensure the user has edit permissions on the post.
-	if ( ! current_user_can( 'edit_post', $post->ID ) ) {
-		return false;
-	}
-
 	/*
 	 * Don't bother enqueuing assets if the post type hasn't opted into autosharing
 	 */


### PR DESCRIPTION
### Description of the Change

Removes the `current_user_can()` check in the `publish_tweet()` function to account for cron jobs publishing a scheduled post. 

The `save_tweet_meta()` function includes a current_user_can check so the data should not be manipulated by unauthorized users in the classic editor. The rest API endpoint uses the `update_post_autoshare_for_twitter_meta_permission_check()` function to implement the `current_user_can()` check.

I wasn't able to figure out how to test this without doing a large refactor of `test_maybe_publish_tweet()`.

Closes #398

### How to test the Change

1. Create a block editor post
2. Enable auto-tweet and an account to tweet from
3. Schedule the post for three minutes for now
4. Return to the All posts screen
5. Make a cup of tea or coffee stating from stone cold water in the kettle
6. Once the scheduled time has past, load a random screen in the WP Dashboard in order to trigger WP-Cron
7. Ensure the tweet is published
8. Enable the classic editor
9. Create a classic editor post
10. Enable auto-tweet and an account to tweet from
11. Schedule the post for three minutes for now
12. Return to the all posts screen
13. Pat the cat/dog for a few minutes explaining what a good cat/dog they are throughout
14. Once the scheduled time has past, load a random screen in the WP Dashboard in order to trigger WP-Cron
15. Ensure the tweet is published

### Changelog Entry
> Fixed - Bug preventing the autosharing of posts for scheduled posts.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @justinmaurerdotdev, @peterwilsoncc 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
